### PR TITLE
Remove orange styling from LOA component

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -15,7 +15,7 @@
                         'fi-black': '#0a0a0a',
                         'fi-dark': '#111111',
                         'fi-gray': '#1a1a1a',
-                        'fi-accent': '#f97316',
+                        'fi-accent': '#8b5cf6',
                     },
                     fontFamily: {
                         'sans': ['Inter', 'system-ui', '-apple-system', 'sans-serif'],
@@ -30,11 +30,11 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
     <style>
         :root {
-            --dynamic-r: 249;
-            --dynamic-g: 115;
-            --dynamic-b: 22;
+            --dynamic-r: 139;
+            --dynamic-g: 92;
+            --dynamic-b: 246;
             --dynamic-color: rgb(var(--dynamic-r), var(--dynamic-g), var(--dynamic-b));
-            --dynamic-color-hex: #f97316;
+            --dynamic-color-hex: #8b5cf6;
         }
         @keyframes pulse-glow { 0%, 100% { opacity: 0.4; } 50% { opacity: 0.8; } }
         @keyframes float { 0%, 100% { transform: translateY(0px); } 50% { transform: translateY(-10px); } }

--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
                         'fi-black': '#0a0a0a',
                         'fi-dark': '#111111',
                         'fi-gray': '#1a1a1a',
-                        'fi-accent': '#f97316',
+                        'fi-accent': '#8b5cf6',
                     },
                     fontFamily: {
                         'sans': ['Inter', 'system-ui', '-apple-system', 'sans-serif'],
@@ -30,11 +30,11 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
     <style>
         :root {
-            --dynamic-r: 249;
-            --dynamic-g: 115;
-            --dynamic-b: 22;
+            --dynamic-r: 139;
+            --dynamic-g: 92;
+            --dynamic-b: 246;
             --dynamic-color: rgb(var(--dynamic-r), var(--dynamic-g), var(--dynamic-b));
-            --dynamic-color-hex: #f97316;
+            --dynamic-color-hex: #8b5cf6;
         }
         @keyframes pulse-glow {
             0%, 100% { opacity: 0.4; }

--- a/partners.html
+++ b/partners.html
@@ -15,7 +15,7 @@
                         'fi-black': '#0a0a0a',
                         'fi-dark': '#111111',
                         'fi-gray': '#1a1a1a',
-                        'fi-accent': '#f97316',
+                        'fi-accent': '#8b5cf6',
                     },
                     fontFamily: {
                         'sans': ['Inter', 'system-ui', '-apple-system', 'sans-serif'],
@@ -30,11 +30,11 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
     <style>
         :root {
-            --dynamic-r: 249;
-            --dynamic-g: 115;
-            --dynamic-b: 22;
+            --dynamic-r: 139;
+            --dynamic-g: 92;
+            --dynamic-b: 246;
             --dynamic-color: rgb(var(--dynamic-r), var(--dynamic-g), var(--dynamic-b));
-            --dynamic-color-hex: #f97316;
+            --dynamic-color-hex: #8b5cf6;
         }
         @keyframes pulse-glow { 0%, 100% { opacity: 0.4; } 50% { opacity: 0.8; } }
         @keyframes float { 0%, 100% { transform: translateY(0px); } 50% { transform: translateY(-10px); } }

--- a/past-performance.html
+++ b/past-performance.html
@@ -15,7 +15,7 @@
                         'fi-black': '#0a0a0a',
                         'fi-dark': '#111111',
                         'fi-gray': '#1a1a1a',
-                        'fi-accent': '#f97316',
+                        'fi-accent': '#8b5cf6',
                     },
                     fontFamily: {
                         'sans': ['Inter', 'system-ui', '-apple-system', 'sans-serif'],
@@ -30,11 +30,11 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
     <style>
         :root {
-            --dynamic-r: 249;
-            --dynamic-g: 115;
-            --dynamic-b: 22;
+            --dynamic-r: 139;
+            --dynamic-g: 92;
+            --dynamic-b: 246;
             --dynamic-color: rgb(var(--dynamic-r), var(--dynamic-g), var(--dynamic-b));
-            --dynamic-color-hex: #f97316;
+            --dynamic-color-hex: #8b5cf6;
         }
         @keyframes pulse-glow { 0%, 100% { opacity: 0.4; } 50% { opacity: 0.8; } }
         @keyframes float { 0%, 100% { transform: translateY(0px); } 50% { transform: translateY(-10px); } }

--- a/services/ai-systems.html
+++ b/services/ai-systems.html
@@ -15,7 +15,7 @@
                         'fi-black': '#0a0a0a',
                         'fi-dark': '#111111',
                         'fi-gray': '#1a1a1a',
-                        'fi-accent': '#f97316',
+                        'fi-accent': '#8b5cf6',
                     },
                     fontFamily: {
                         'sans': ['Inter', 'system-ui', '-apple-system', 'sans-serif'],
@@ -30,11 +30,11 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
     <style>
         :root {
-            --dynamic-r: 249;
-            --dynamic-g: 115;
-            --dynamic-b: 22;
+            --dynamic-r: 139;
+            --dynamic-g: 92;
+            --dynamic-b: 246;
             --dynamic-color: rgb(var(--dynamic-r), var(--dynamic-g), var(--dynamic-b));
-            --dynamic-color-hex: #f97316;
+            --dynamic-color-hex: #8b5cf6;
         }
         @keyframes pulse-glow { 0%, 100% { opacity: 0.4; } 50% { opacity: 0.8; } }
         @keyframes float { 0%, 100% { transform: translateY(0px); } 50% { transform: translateY(-10px); } }

--- a/services/software-engineering.html
+++ b/services/software-engineering.html
@@ -15,7 +15,7 @@
                         'fi-black': '#0a0a0a',
                         'fi-dark': '#111111',
                         'fi-gray': '#1a1a1a',
-                        'fi-accent': '#f97316',
+                        'fi-accent': '#8b5cf6',
                     },
                     fontFamily: {
                         'sans': ['Inter', 'system-ui', '-apple-system', 'sans-serif'],
@@ -30,11 +30,11 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
     <style>
         :root {
-            --dynamic-r: 249;
-            --dynamic-g: 115;
-            --dynamic-b: 22;
+            --dynamic-r: 139;
+            --dynamic-g: 92;
+            --dynamic-b: 246;
             --dynamic-color: rgb(var(--dynamic-r), var(--dynamic-g), var(--dynamic-b));
-            --dynamic-color-hex: #f97316;
+            --dynamic-color-hex: #8b5cf6;
         }
         @keyframes pulse-glow {
             0%, 100% { opacity: 0.4; }

--- a/services/technical-advisory.html
+++ b/services/technical-advisory.html
@@ -15,7 +15,7 @@
                         'fi-black': '#0a0a0a',
                         'fi-dark': '#111111',
                         'fi-gray': '#1a1a1a',
-                        'fi-accent': '#f97316',
+                        'fi-accent': '#8b5cf6',
                     },
                     fontFamily: {
                         'sans': ['Inter', 'system-ui', '-apple-system', 'sans-serif'],
@@ -30,11 +30,11 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
     <style>
         :root {
-            --dynamic-r: 249;
-            --dynamic-g: 115;
-            --dynamic-b: 22;
+            --dynamic-r: 139;
+            --dynamic-g: 92;
+            --dynamic-b: 246;
             --dynamic-color: rgb(var(--dynamic-r), var(--dynamic-g), var(--dynamic-b));
-            --dynamic-color-hex: #f97316;
+            --dynamic-color-hex: #8b5cf6;
         }
         @keyframes pulse-glow { 0%, 100% { opacity: 0.4; } 50% { opacity: 0.8; } }
         @keyframes float { 0%, 100% { transform: translateY(0px); } 50% { transform: translateY(-10px); } }


### PR DESCRIPTION
Change the initial CSS variable values from orange (#f97316) to purple (#8b5cf6) to match the first color in the Three.js animation palette. This eliminates the orange flash that was visible on page load.

## Description

Brief description of the changes in this PR.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Changes Made

- Change 1
- Change 2

## Testing

Describe how you tested your changes:

- [ ] Tested locally in browser
- [ ] Tested on mobile viewport
- [ ] Tested in multiple browsers (list which ones)

## Checklist

- [ ] My changes follow the project's code style
- [ ] I have tested my changes locally
- [ ] I have updated documentation if needed
- [ ] My changes don't break existing functionality

## Screenshots (if applicable)

Add screenshots showing the changes.

## Related Issues

Closes #(issue number)
