### PR TITLE
Fix mobile header menu scrolling issue

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -158,7 +158,7 @@
         .form-input::placeholder { color: #737373; }
         .form-label { display: block; color: #a3a3a3; font-size: 0.875rem; font-weight: 500; margin-bottom: 8px; }
         @media (max-width: 768px) {
-            .desktop-nav { display: none; }
+            .desktop-nav { display: none !important; }
             .mobile-menu-btn { display: flex; flex-direction: column; justify-content: center; align-items: center; width: 40px; height: 40px; background: transparent; border: none; cursor: pointer; gap: 5px; z-index: 60; }
             .mobile-menu-btn span { display: block; width: 24px; height: 2px; background: #ffffff; transition: all 0.3s ease; }
             .mobile-menu-btn.active span:nth-child(1) { transform: rotate(45deg) translate(5px, 5px); }
@@ -196,7 +196,7 @@
                     </div>
                     <span class="text-xl font-semibold text-white tracking-tight">Federal<span class="text-dynamic-accent">Innovations</span></span>
                 </a>
-                <div class="desktop-nav flex items-center space-x-8">
+                <div class="desktop-nav hidden md:flex items-center space-x-8">
                     <a href="/" class="nav-link font-medium">Home</a>
                     <div class="dropdown">
                         <button class="nav-link font-medium flex items-center gap-1">

--- a/index.html
+++ b/index.html
@@ -394,7 +394,7 @@
         }
         @media (max-width: 768px) {
             .desktop-nav {
-                display: none;
+                display: none !important;
             }
             .mobile-menu-btn {
                 display: flex;
@@ -512,7 +512,7 @@
                 </div>
 
                 <!-- Desktop Navigation -->
-                <div class="desktop-nav flex items-center space-x-8">
+                <div class="desktop-nav hidden md:flex items-center space-x-8">
                     <a href="/" class="nav-link font-medium">Home</a>
 
                     <!-- Services Dropdown -->

--- a/partners.html
+++ b/partners.html
@@ -141,7 +141,7 @@
         .mobile-menu-btn { display: none; }
         .mobile-menu { display: none; }
         @media (max-width: 768px) {
-            .desktop-nav { display: none; }
+            .desktop-nav { display: none !important; }
             .mobile-menu-btn { display: flex; flex-direction: column; justify-content: center; align-items: center; width: 40px; height: 40px; background: transparent; border: none; cursor: pointer; gap: 5px; z-index: 60; }
             .mobile-menu-btn span { display: block; width: 24px; height: 2px; background: #ffffff; transition: all 0.3s ease; }
             .mobile-menu-btn.active span:nth-child(1) { transform: rotate(45deg) translate(5px, 5px); }
@@ -179,7 +179,7 @@
                     </div>
                     <span class="text-xl font-semibold text-white tracking-tight">Federal<span class="text-dynamic-accent">Innovations</span></span>
                 </a>
-                <div class="desktop-nav flex items-center space-x-8">
+                <div class="desktop-nav hidden md:flex items-center space-x-8">
                     <a href="/" class="nav-link font-medium">Home</a>
                     <div class="dropdown">
                         <button class="nav-link font-medium flex items-center gap-1">

--- a/past-performance.html
+++ b/past-performance.html
@@ -141,7 +141,7 @@
         .mobile-menu-btn { display: none; }
         .mobile-menu { display: none; }
         @media (max-width: 768px) {
-            .desktop-nav { display: none; }
+            .desktop-nav { display: none !important; }
             .mobile-menu-btn { display: flex; flex-direction: column; justify-content: center; align-items: center; width: 40px; height: 40px; background: transparent; border: none; cursor: pointer; gap: 5px; z-index: 60; }
             .mobile-menu-btn span { display: block; width: 24px; height: 2px; background: #ffffff; transition: all 0.3s ease; }
             .mobile-menu-btn.active span:nth-child(1) { transform: rotate(45deg) translate(5px, 5px); }
@@ -179,7 +179,7 @@
                     </div>
                     <span class="text-xl font-semibold text-white tracking-tight">Federal<span class="text-dynamic-accent">Innovations</span></span>
                 </a>
-                <div class="desktop-nav flex items-center space-x-8">
+                <div class="desktop-nav hidden md:flex items-center space-x-8">
                     <a href="/" class="nav-link font-medium">Home</a>
                     <div class="dropdown">
                         <button class="nav-link font-medium flex items-center gap-1">

--- a/services/ai-systems.html
+++ b/services/ai-systems.html
@@ -144,7 +144,7 @@
         .mobile-menu-btn { display: none; }
         .mobile-menu { display: none; }
         @media (max-width: 768px) {
-            .desktop-nav { display: none; }
+            .desktop-nav { display: none !important; }
             .mobile-menu-btn { display: flex; flex-direction: column; justify-content: center; align-items: center; width: 40px; height: 40px; background: transparent; border: none; cursor: pointer; gap: 5px; z-index: 60; }
             .mobile-menu-btn span { display: block; width: 24px; height: 2px; background: #ffffff; transition: all 0.3s ease; }
             .mobile-menu-btn.active span:nth-child(1) { transform: rotate(45deg) translate(5px, 5px); }
@@ -183,7 +183,7 @@
                     </div>
                     <span class="text-xl font-semibold text-white tracking-tight">Federal<span class="text-dynamic-accent">Innovations</span></span>
                 </a>
-                <div class="desktop-nav flex items-center space-x-8">
+                <div class="desktop-nav hidden md:flex items-center space-x-8">
                     <a href="/" class="nav-link font-medium">Home</a>
                     <div class="dropdown">
                         <button class="nav-link active font-medium flex items-center gap-1">

--- a/services/software-engineering.html
+++ b/services/software-engineering.html
@@ -187,7 +187,7 @@
         .mobile-menu-btn { display: none; }
         .mobile-menu { display: none; }
         @media (max-width: 768px) {
-            .desktop-nav { display: none; }
+            .desktop-nav { display: none !important; }
             .mobile-menu-btn {
                 display: flex; flex-direction: column; justify-content: center; align-items: center;
                 width: 40px; height: 40px; background: transparent; border: none; cursor: pointer; gap: 5px; z-index: 60;
@@ -234,7 +234,7 @@
                     </div>
                     <span class="text-xl font-semibold text-white tracking-tight">Federal<span class="text-dynamic-accent">Innovations</span></span>
                 </a>
-                <div class="desktop-nav flex items-center space-x-8">
+                <div class="desktop-nav hidden md:flex items-center space-x-8">
                     <a href="/" class="nav-link font-medium">Home</a>
                     <div class="dropdown">
                         <button class="nav-link active font-medium flex items-center gap-1">

--- a/services/technical-advisory.html
+++ b/services/technical-advisory.html
@@ -144,7 +144,7 @@
         .mobile-menu-btn { display: none; }
         .mobile-menu { display: none; }
         @media (max-width: 768px) {
-            .desktop-nav { display: none; }
+            .desktop-nav { display: none !important; }
             .mobile-menu-btn { display: flex; flex-direction: column; justify-content: center; align-items: center; width: 40px; height: 40px; background: transparent; border: none; cursor: pointer; gap: 5px; z-index: 60; }
             .mobile-menu-btn span { display: block; width: 24px; height: 2px; background: #ffffff; transition: all 0.3s ease; }
             .mobile-menu-btn.active span:nth-child(1) { transform: rotate(45deg) translate(5px, 5px); }
@@ -183,7 +183,7 @@
                     </div>
                     <span class="text-xl font-semibold text-white tracking-tight">Federal<span class="text-dynamic-accent">Innovations</span></span>
                 </a>
-                <div class="desktop-nav flex items-center space-x-8">
+                <div class="desktop-nav hidden md:flex items-center space-x-8">
                     <a href="/" class="nav-link font-medium">Home</a>
                     <div class="dropdown">
                         <button class="nav-link active font-medium flex items-center gap-1">


### PR DESCRIPTION
The desktop navigation was causing horizontal scroll on mobile because Tailwind's `flex` class was overriding the custom CSS `display: none` in the media query due to CSS specificity.

Fixed by:
- Adding `hidden md:flex` Tailwind classes for responsive behavior
- Adding `!important` to CSS media query for extra safety

## Description

Brief description of the changes in this PR.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Changes Made

- Change 1
- Change 2

## Testing

Describe how you tested your changes:

- [ ] Tested locally in browser
- [ ] Tested on mobile viewport
- [ ] Tested in multiple browsers (list which ones)

## Checklist

- [ ] My changes follow the project's code style
- [ ] I have tested my changes locally
- [ ] I have updated documentation if needed
- [ ] My changes don't break existing functionality

## Screenshots (if applicable)

Add screenshots showing the changes.

## Related Issues

Closes #(issue number)
