### PR TITLE
Add Cloudflare Worker deployment workflow and update copyright year

### DIFF
--- a/.github/workflows/deploy-worker.yml
+++ b/.github/workflows/deploy-worker.yml
@@ -1,0 +1,20 @@
+name: Deploy Cloudflare Worker
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'workers/**'
+      - 'wrangler.toml'
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    name: Deploy Worker
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Deploy to Cloudflare Workers
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/contact.html
+++ b/contact.html
@@ -398,7 +398,7 @@
 
         <footer class="py-8 px-6 md:px-12 lg:px-20 border-t border-white/5">
             <div class="flex flex-col md:flex-row items-center justify-between gap-4">
-                <p class="text-neutral-600 text-sm">&copy; 2025 Federal Innovations. All rights reserved.</p>
+                <p class="text-neutral-600 text-sm">&copy; 2026 Federal Innovations. All rights reserved.</p>
                 <div class="flex items-center space-x-1 text-neutral-600 text-sm">
                     <span>Washington, D.C.</span>
                     <span class="text-neutral-700">|</span>

--- a/index.html
+++ b/index.html
@@ -627,7 +627,7 @@
         <footer class="py-8 px-6 md:px-12 lg:px-20 border-t border-white/5">
             <div class="flex flex-col md:flex-row items-center justify-between gap-4">
                 <p class="text-neutral-600 text-sm">
-                    &copy; 2025 Federal Innovations. All rights reserved.
+                    &copy; 2026 Federal Innovations. All rights reserved.
                 </p>
                 <div class="flex items-center space-x-1 text-neutral-600 text-sm">
                     <span>Washington, D.C.</span>

--- a/partners.html
+++ b/partners.html
@@ -376,7 +376,7 @@
 
         <footer class="py-8 px-6 md:px-12 lg:px-20 border-t border-white/5">
             <div class="flex flex-col md:flex-row items-center justify-between gap-4">
-                <p class="text-neutral-600 text-sm">&copy; 2025 Federal Innovations. All rights reserved.</p>
+                <p class="text-neutral-600 text-sm">&copy; 2026 Federal Innovations. All rights reserved.</p>
                 <div class="flex items-center space-x-1 text-neutral-600 text-sm">
                     <span>Washington, D.C.</span>
                     <span class="text-neutral-700">|</span>

--- a/past-performance.html
+++ b/past-performance.html
@@ -364,7 +364,7 @@
 
         <footer class="py-8 px-6 md:px-12 lg:px-20 border-t border-white/5">
             <div class="flex flex-col md:flex-row items-center justify-between gap-4">
-                <p class="text-neutral-600 text-sm">&copy; 2025 Federal Innovations. All rights reserved.</p>
+                <p class="text-neutral-600 text-sm">&copy; 2026 Federal Innovations. All rights reserved.</p>
                 <div class="flex items-center space-x-1 text-neutral-600 text-sm">
                     <span>Washington, D.C.</span>
                     <span class="text-neutral-700">|</span>

--- a/services/ai-systems.html
+++ b/services/ai-systems.html
@@ -355,7 +355,7 @@
 
         <footer class="py-8 px-6 md:px-12 lg:px-20 border-t border-white/5">
             <div class="flex flex-col md:flex-row items-center justify-between gap-4">
-                <p class="text-neutral-600 text-sm">&copy; 2025 Federal Innovations. All rights reserved.</p>
+                <p class="text-neutral-600 text-sm">&copy; 2026 Federal Innovations. All rights reserved.</p>
                 <div class="flex items-center space-x-1 text-neutral-600 text-sm">
                     <span>Washington, D.C.</span>
                     <span class="text-neutral-700">|</span>

--- a/services/software-engineering.html
+++ b/services/software-engineering.html
@@ -390,7 +390,7 @@
 
         <footer class="py-8 px-6 md:px-12 lg:px-20 border-t border-white/5">
             <div class="flex flex-col md:flex-row items-center justify-between gap-4">
-                <p class="text-neutral-600 text-sm">&copy; 2025 Federal Innovations. All rights reserved.</p>
+                <p class="text-neutral-600 text-sm">&copy; 2026 Federal Innovations. All rights reserved.</p>
                 <div class="flex items-center space-x-1 text-neutral-600 text-sm">
                     <span>Washington, D.C.</span>
                     <span class="text-neutral-700">|</span>

--- a/services/technical-advisory.html
+++ b/services/technical-advisory.html
@@ -340,7 +340,7 @@
 
         <footer class="py-8 px-6 md:px-12 lg:px-20 border-t border-white/5">
             <div class="flex flex-col md:flex-row items-center justify-between gap-4">
-                <p class="text-neutral-600 text-sm">&copy; 2025 Federal Innovations. All rights reserved.</p>
+                <p class="text-neutral-600 text-sm">&copy; 2026 Federal Innovations. All rights reserved.</p>
                 <div class="flex items-center space-x-1 text-neutral-600 text-sm">
                     <span>Washington, D.C.</span>
                     <span class="text-neutral-700">|</span>


### PR DESCRIPTION
## Description

This PR adds automated deployment infrastructure for Cloudflare Workers and updates copyright notices across the site to reflect 2026.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Documentation update

## Changes Made

- Added GitHub Actions workflow (`.github/workflows/deploy-worker.yml`) to automatically deploy Cloudflare Workers on push to main branch when worker files or `wrangler.toml` change
- Updated copyright year from 2025 to 2026 in footer across all HTML pages (index.html, contact.html, partners.html, past-performance.html, and all service pages)
- Added `.nojekyll` file to disable Jekyll processing on GitHub Pages

## Testing

- [x] Workflow syntax is valid and follows GitHub Actions best practices
- [x] Cloudflare wrangler-action@v3 is a stable, widely-used action

## Checklist

- [x] My changes follow the project's code style
- [x] My changes don't break existing functionality
- [x] Copyright updates are consistent across all pages

## Related Issues

N/A

https://claude.ai/code/session_01MLGJvEeRW9AXTz9D69ZuDy