### PR TITLE
Generalize subdomain redirect logic to handle all paths

### DIFF
--- a/js/spa-router.js
+++ b/js/spa-router.js
@@ -20,12 +20,6 @@
     'technical-advisory': 'pages/technical-advisory.html'
   };
 
-  // Known page names for link interception matching
-  var PAGE_NAMES = [
-    'contact', 'partners', 'past-performance',
-    'software-engineering', 'ai-systems', 'technical-advisory'
-  ];
-
   // Paths that should be left to default browser behaviour
   var EXCLUDED_PREFIXES = ['/assets', '/css', '/js', '/pages', '/images'];
 
@@ -207,11 +201,14 @@
       return;
     }
 
-    // Known page paths → redirect to subdomain
+    // All remaining paths → redirect to subdomain
     var strippedHref = href.replace(/^\//, '').replace(/\.html$/, '');
-    if (PAGE_NAMES.indexOf(strippedHref) !== -1) {
+    if (strippedHref) {
       e.preventDefault();
-      window.location.href = 'https://' + strippedHref + '.federalinnovations.com';
+      var segments = strippedHref.split('/').filter(Boolean);
+      var firstSegment = segments[0];
+      var remainingPath = segments.slice(1).join('/');
+      window.location.href = 'https://' + firstSegment + '.federalinnovations.com' + (remainingPath ? '/' + remainingPath : '');
       return;
     }
   }


### PR DESCRIPTION
## Description

Refactored the subdomain redirect logic in the SPA router to handle all remaining paths dynamically, rather than maintaining a hardcoded list of known page names. This change makes the router more flexible and reduces maintenance burden when adding new pages.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Changes Made

- Removed the hardcoded `PAGE_NAMES` array that listed specific pages for subdomain redirection
- Updated the redirect logic to accept any non-excluded path and dynamically construct the subdomain URL
- Added support for nested paths by parsing URL segments and preserving path structure in the subdomain redirect
- Changed the condition from checking against a whitelist to checking if a path exists after stripping leading slashes and `.html` extensions

## Testing

- [x] Tested locally in browser

The change maintains backward compatibility with existing page redirects while enabling new pages to be automatically redirected without code modifications.

## Checklist

- [x] My changes follow the project's code style
- [x] I have tested my changes locally
- [x] My changes don't break existing functionality

https://claude.ai/code/session_01GANzWFKB8PbYrUv2YM3YW1