### PR TITLE
Add liquid glass effect with SVG filter to all pages

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -81,6 +81,9 @@
             --dynamic-b: 22;
             --dynamic-color: rgb(var(--dynamic-r), var(--dynamic-g), var(--dynamic-b));
             --dynamic-color-hex: #f97316;
+            --glass-frost: 0.1;
+            --glass-saturation: 1.2;
+            --filter-id: url(#glass-filter-_r_b_);
         }
         @keyframes pulse-glow { 0%, 100% { opacity: 0.4; } 50% { opacity: 0.8; } }
         @keyframes float { 0%, 100% { transform: translateY(0px); } 50% { transform: translateY(-10px); } }
@@ -174,9 +177,20 @@
             .mobile-dropdown-item { font-size: 1rem; color: #737373; transition: color 0.3s ease; }
             .mobile-dropdown-item:hover { color: var(--dynamic-color); }
         }
+        /* Liquid Glass Effect */
+        .liquidglass { position: fixed; left: 50%; top: 50%; transform: translate(-50%); z-index: 1; width: 340px; background: hsl(0 0% 0% / var(--glass-frost, 0)); -webkit-backdrop-filter: var(--filter-id, url(#glass-filter)) saturate(var(--glass-saturation, 1)); backdrop-filter: var(--filter-id, url(#glass-filter)) saturate(var(--glass-saturation, 1)); box-shadow: inset 0 0 2px 1px #ffffff59, inset 0 0 10px 4px #ffffff26, inset 0 4px 16px #11111a0d, inset 0 8px 24px #11111a0d, inset 0 6px 56px #11111a0d; box-shadow: inset 0 0 2px 1px lab(100% 0 0 / .35), inset 0 0 10px 4px lab(100% 0 0 / .15), inset 0 4px 16px lab(5.32203% 1.61424 -5.88284 / .0509804), inset 0 8px 24px lab(5.32203% 1.61424 -5.88284 / .0509804), inset 0 6px 56px lab(5.32203% 1.61424 -5.88284 / .0509804); border-radius: 9999px; height: 140px; pointer-events: none; }
+        .glass-surface__filter { pointer-events: none; opacity: 0; z-index: -1; width: 100%; height: 100%; position: absolute; inset: 0; }
     </style>
 </head>
 <body class="bg-fi-black min-h-screen font-sans antialiased overflow-x-hidden">
+    <!-- Liquid Glass SVG Filter -->
+    <svg class="glass-surface__filter" aria-hidden="true">
+        <filter id="glass-filter-_r_b_" x="-50%" y="-50%" width="200%" height="200%" color-interpolation-filters="sRGB">
+            <feGaussianBlur in="SourceGraphic" stdDeviation="10" />
+        </filter>
+    </svg>
+    <!-- Liquid Glass Element -->
+    <div class="liquidglass"></div>
     <canvas id="threeCanvas" style="position: fixed; top: 0; left: 0; width: 100%; height: 100%; z-index: 0; pointer-events: none;"></canvas>
     <div class="mouse-glow" id="mouseGlow"></div>
     <div class="fixed inset-0 opacity-[0.02] parallax-layer parallax-slow" id="gridBg" style="background-image: linear-gradient(#fff 1px, transparent 1px), linear-gradient(90deg, #fff 1px, transparent 1px); background-size: 50px 50px;"></div>

--- a/index.html
+++ b/index.html
@@ -83,6 +83,9 @@
             --dynamic-b: 22;
             --dynamic-color: rgb(var(--dynamic-r), var(--dynamic-g), var(--dynamic-b));
             --dynamic-color-hex: #f97316;
+            --glass-frost: 0.1;
+            --glass-saturation: 1.2;
+            --filter-id: url(#glass-filter-_r_b_);
         }
         @keyframes shimmer {
             0% { background-position: -200% center; }
@@ -465,9 +468,45 @@
             transform: translateY(-10px);
             transition: opacity 0.2s ease, transform 0.2s ease;
         }
+        /* Liquid Glass Effect */
+        .liquidglass {
+            position: fixed;
+            left: 50%;
+            top: 50%;
+            transform: translate(-50%);
+            z-index: 1;
+            width: 340px;
+            background: hsl(0 0% 0% / var(--glass-frost, 0));
+            -webkit-backdrop-filter: var(--filter-id, url(#glass-filter)) saturate(var(--glass-saturation, 1));
+            backdrop-filter: var(--filter-id, url(#glass-filter)) saturate(var(--glass-saturation, 1));
+            box-shadow: inset 0 0 2px 1px #ffffff59, inset 0 0 10px 4px #ffffff26, inset 0 4px 16px #11111a0d, inset 0 8px 24px #11111a0d, inset 0 6px 56px #11111a0d;
+            box-shadow: inset 0 0 2px 1px lab(100% 0 0 / .35), inset 0 0 10px 4px lab(100% 0 0 / .15), inset 0 4px 16px lab(5.32203% 1.61424 -5.88284 / .0509804), inset 0 8px 24px lab(5.32203% 1.61424 -5.88284 / .0509804), inset 0 6px 56px lab(5.32203% 1.61424 -5.88284 / .0509804);
+            border-radius: 9999px;
+            height: 140px;
+            pointer-events: none;
+        }
+        .glass-surface__filter {
+            pointer-events: none;
+            opacity: 0;
+            z-index: -1;
+            width: 100%;
+            height: 100%;
+            position: absolute;
+            inset: 0;
+        }
     </style>
 </head>
 <body class="bg-fi-black min-h-screen font-sans antialiased overflow-x-hidden">
+    <!-- Liquid Glass SVG Filter -->
+    <svg class="glass-surface__filter" aria-hidden="true">
+        <filter id="glass-filter-_r_b_" x="-50%" y="-50%" width="200%" height="200%" color-interpolation-filters="sRGB">
+            <feGaussianBlur in="SourceGraphic" stdDeviation="10" />
+        </filter>
+    </svg>
+
+    <!-- Liquid Glass Element -->
+    <div class="liquidglass"></div>
+
     <!-- WebGL particle background -->
     <canvas id="canvas" style="position: fixed; top: 0; left: 0; width: 100%; height: 100%; z-index: 0; pointer-events: none;"></canvas>
 

--- a/partners.html
+++ b/partners.html
@@ -81,6 +81,9 @@
             --dynamic-b: 22;
             --dynamic-color: rgb(var(--dynamic-r), var(--dynamic-g), var(--dynamic-b));
             --dynamic-color-hex: #f97316;
+            --glass-frost: 0.1;
+            --glass-saturation: 1.2;
+            --filter-id: url(#glass-filter-_r_b_);
         }
         @keyframes pulse-glow { 0%, 100% { opacity: 0.4; } 50% { opacity: 0.8; } }
         @keyframes float { 0%, 100% { transform: translateY(0px); } 50% { transform: translateY(-10px); } }
@@ -157,9 +160,20 @@
             .mobile-dropdown-item { font-size: 1rem; color: #737373; transition: color 0.3s ease; }
             .mobile-dropdown-item:hover { color: var(--dynamic-color); }
         }
+        /* Liquid Glass Effect */
+        .liquidglass { position: fixed; left: 50%; top: 50%; transform: translate(-50%); z-index: 1; width: 340px; background: hsl(0 0% 0% / var(--glass-frost, 0)); -webkit-backdrop-filter: var(--filter-id, url(#glass-filter)) saturate(var(--glass-saturation, 1)); backdrop-filter: var(--filter-id, url(#glass-filter)) saturate(var(--glass-saturation, 1)); box-shadow: inset 0 0 2px 1px #ffffff59, inset 0 0 10px 4px #ffffff26, inset 0 4px 16px #11111a0d, inset 0 8px 24px #11111a0d, inset 0 6px 56px #11111a0d; box-shadow: inset 0 0 2px 1px lab(100% 0 0 / .35), inset 0 0 10px 4px lab(100% 0 0 / .15), inset 0 4px 16px lab(5.32203% 1.61424 -5.88284 / .0509804), inset 0 8px 24px lab(5.32203% 1.61424 -5.88284 / .0509804), inset 0 6px 56px lab(5.32203% 1.61424 -5.88284 / .0509804); border-radius: 9999px; height: 140px; pointer-events: none; }
+        .glass-surface__filter { pointer-events: none; opacity: 0; z-index: -1; width: 100%; height: 100%; position: absolute; inset: 0; }
     </style>
 </head>
 <body class="bg-fi-black min-h-screen font-sans antialiased overflow-x-hidden">
+    <!-- Liquid Glass SVG Filter -->
+    <svg class="glass-surface__filter" aria-hidden="true">
+        <filter id="glass-filter-_r_b_" x="-50%" y="-50%" width="200%" height="200%" color-interpolation-filters="sRGB">
+            <feGaussianBlur in="SourceGraphic" stdDeviation="10" />
+        </filter>
+    </svg>
+    <!-- Liquid Glass Element -->
+    <div class="liquidglass"></div>
     <canvas id="threeCanvas" style="position: fixed; top: 0; left: 0; width: 100%; height: 100%; z-index: 0; pointer-events: none;"></canvas>
     <div class="mouse-glow" id="mouseGlow"></div>
     <div class="fixed inset-0 opacity-[0.02] parallax-layer parallax-slow" id="gridBg" style="background-image: linear-gradient(#fff 1px, transparent 1px), linear-gradient(90deg, #fff 1px, transparent 1px); background-size: 50px 50px;"></div>

--- a/past-performance.html
+++ b/past-performance.html
@@ -81,6 +81,9 @@
             --dynamic-b: 22;
             --dynamic-color: rgb(var(--dynamic-r), var(--dynamic-g), var(--dynamic-b));
             --dynamic-color-hex: #f97316;
+            --glass-frost: 0.1;
+            --glass-saturation: 1.2;
+            --filter-id: url(#glass-filter-_r_b_);
         }
         @keyframes pulse-glow { 0%, 100% { opacity: 0.4; } 50% { opacity: 0.8; } }
         @keyframes float { 0%, 100% { transform: translateY(0px); } 50% { transform: translateY(-10px); } }
@@ -157,9 +160,20 @@
             .mobile-dropdown-item { font-size: 1rem; color: #737373; transition: color 0.3s ease; }
             .mobile-dropdown-item:hover { color: var(--dynamic-color); }
         }
+        /* Liquid Glass Effect */
+        .liquidglass { position: fixed; left: 50%; top: 50%; transform: translate(-50%); z-index: 1; width: 340px; background: hsl(0 0% 0% / var(--glass-frost, 0)); -webkit-backdrop-filter: var(--filter-id, url(#glass-filter)) saturate(var(--glass-saturation, 1)); backdrop-filter: var(--filter-id, url(#glass-filter)) saturate(var(--glass-saturation, 1)); box-shadow: inset 0 0 2px 1px #ffffff59, inset 0 0 10px 4px #ffffff26, inset 0 4px 16px #11111a0d, inset 0 8px 24px #11111a0d, inset 0 6px 56px #11111a0d; box-shadow: inset 0 0 2px 1px lab(100% 0 0 / .35), inset 0 0 10px 4px lab(100% 0 0 / .15), inset 0 4px 16px lab(5.32203% 1.61424 -5.88284 / .0509804), inset 0 8px 24px lab(5.32203% 1.61424 -5.88284 / .0509804), inset 0 6px 56px lab(5.32203% 1.61424 -5.88284 / .0509804); border-radius: 9999px; height: 140px; pointer-events: none; }
+        .glass-surface__filter { pointer-events: none; opacity: 0; z-index: -1; width: 100%; height: 100%; position: absolute; inset: 0; }
     </style>
 </head>
 <body class="bg-fi-black min-h-screen font-sans antialiased overflow-x-hidden">
+    <!-- Liquid Glass SVG Filter -->
+    <svg class="glass-surface__filter" aria-hidden="true">
+        <filter id="glass-filter-_r_b_" x="-50%" y="-50%" width="200%" height="200%" color-interpolation-filters="sRGB">
+            <feGaussianBlur in="SourceGraphic" stdDeviation="10" />
+        </filter>
+    </svg>
+    <!-- Liquid Glass Element -->
+    <div class="liquidglass"></div>
     <canvas id="threeCanvas" style="position: fixed; top: 0; left: 0; width: 100%; height: 100%; z-index: 0; pointer-events: none;"></canvas>
     <div class="mouse-glow" id="mouseGlow"></div>
     <div class="fixed inset-0 opacity-[0.02] parallax-layer parallax-slow" id="gridBg" style="background-image: linear-gradient(#fff 1px, transparent 1px), linear-gradient(90deg, #fff 1px, transparent 1px); background-size: 50px 50px;"></div>

--- a/services/ai-systems.html
+++ b/services/ai-systems.html
@@ -83,6 +83,9 @@
             --dynamic-b: 22;
             --dynamic-color: rgb(var(--dynamic-r), var(--dynamic-g), var(--dynamic-b));
             --dynamic-color-hex: #f97316;
+            --glass-frost: 0.1;
+            --glass-saturation: 1.2;
+            --filter-id: url(#glass-filter-_r_b_);
         }
         @keyframes pulse-glow { 0%, 100% { opacity: 0.4; } 50% { opacity: 0.8; } }
         @keyframes float { 0%, 100% { transform: translateY(0px); } 50% { transform: translateY(-10px); } }
@@ -161,9 +164,20 @@
             .mobile-dropdown-item:hover { color: var(--dynamic-color); }
             .mobile-dropdown-item.active { color: var(--dynamic-color); }
         }
+        /* Liquid Glass Effect */
+        .liquidglass { position: fixed; left: 50%; top: 50%; transform: translate(-50%); z-index: 1; width: 340px; background: hsl(0 0% 0% / var(--glass-frost, 0)); -webkit-backdrop-filter: var(--filter-id, url(#glass-filter)) saturate(var(--glass-saturation, 1)); backdrop-filter: var(--filter-id, url(#glass-filter)) saturate(var(--glass-saturation, 1)); box-shadow: inset 0 0 2px 1px #ffffff59, inset 0 0 10px 4px #ffffff26, inset 0 4px 16px #11111a0d, inset 0 8px 24px #11111a0d, inset 0 6px 56px #11111a0d; box-shadow: inset 0 0 2px 1px lab(100% 0 0 / .35), inset 0 0 10px 4px lab(100% 0 0 / .15), inset 0 4px 16px lab(5.32203% 1.61424 -5.88284 / .0509804), inset 0 8px 24px lab(5.32203% 1.61424 -5.88284 / .0509804), inset 0 6px 56px lab(5.32203% 1.61424 -5.88284 / .0509804); border-radius: 9999px; height: 140px; pointer-events: none; }
+        .glass-surface__filter { pointer-events: none; opacity: 0; z-index: -1; width: 100%; height: 100%; position: absolute; inset: 0; }
     </style>
 </head>
 <body class="bg-fi-black min-h-screen font-sans antialiased overflow-x-hidden">
+    <!-- Liquid Glass SVG Filter -->
+    <svg class="glass-surface__filter" aria-hidden="true">
+        <filter id="glass-filter-_r_b_" x="-50%" y="-50%" width="200%" height="200%" color-interpolation-filters="sRGB">
+            <feGaussianBlur in="SourceGraphic" stdDeviation="10" />
+        </filter>
+    </svg>
+    <!-- Liquid Glass Element -->
+    <div class="liquidglass"></div>
     <canvas id="threeCanvas" style="position: fixed; top: 0; left: 0; width: 100%; height: 100%; z-index: 0; pointer-events: none;"></canvas>
     <div class="mouse-glow" id="mouseGlow"></div>
     <div class="fixed inset-0 opacity-[0.02] parallax-layer parallax-slow" id="gridBg" style="background-image: linear-gradient(#fff 1px, transparent 1px), linear-gradient(90deg, #fff 1px, transparent 1px); background-size: 50px 50px;"></div>

--- a/services/software-engineering.html
+++ b/services/software-engineering.html
@@ -83,6 +83,9 @@
             --dynamic-b: 22;
             --dynamic-color: rgb(var(--dynamic-r), var(--dynamic-g), var(--dynamic-b));
             --dynamic-color-hex: #f97316;
+            --glass-frost: 0.1;
+            --glass-saturation: 1.2;
+            --filter-id: url(#glass-filter-_r_b_);
         }
         @keyframes pulse-glow {
             0%, 100% { opacity: 0.4; }
@@ -212,9 +215,20 @@
             .mobile-dropdown-item:hover { color: var(--dynamic-color); }
             .mobile-dropdown-item.active { color: var(--dynamic-color); }
         }
+        /* Liquid Glass Effect */
+        .liquidglass { position: fixed; left: 50%; top: 50%; transform: translate(-50%); z-index: 1; width: 340px; background: hsl(0 0% 0% / var(--glass-frost, 0)); -webkit-backdrop-filter: var(--filter-id, url(#glass-filter)) saturate(var(--glass-saturation, 1)); backdrop-filter: var(--filter-id, url(#glass-filter)) saturate(var(--glass-saturation, 1)); box-shadow: inset 0 0 2px 1px #ffffff59, inset 0 0 10px 4px #ffffff26, inset 0 4px 16px #11111a0d, inset 0 8px 24px #11111a0d, inset 0 6px 56px #11111a0d; box-shadow: inset 0 0 2px 1px lab(100% 0 0 / .35), inset 0 0 10px 4px lab(100% 0 0 / .15), inset 0 4px 16px lab(5.32203% 1.61424 -5.88284 / .0509804), inset 0 8px 24px lab(5.32203% 1.61424 -5.88284 / .0509804), inset 0 6px 56px lab(5.32203% 1.61424 -5.88284 / .0509804); border-radius: 9999px; height: 140px; pointer-events: none; }
+        .glass-surface__filter { pointer-events: none; opacity: 0; z-index: -1; width: 100%; height: 100%; position: absolute; inset: 0; }
     </style>
 </head>
 <body class="bg-fi-black min-h-screen font-sans antialiased overflow-x-hidden">
+    <!-- Liquid Glass SVG Filter -->
+    <svg class="glass-surface__filter" aria-hidden="true">
+        <filter id="glass-filter-_r_b_" x="-50%" y="-50%" width="200%" height="200%" color-interpolation-filters="sRGB">
+            <feGaussianBlur in="SourceGraphic" stdDeviation="10" />
+        </filter>
+    </svg>
+    <!-- Liquid Glass Element -->
+    <div class="liquidglass"></div>
     <canvas id="threeCanvas" style="position: fixed; top: 0; left: 0; width: 100%; height: 100%; z-index: 0; pointer-events: none;"></canvas>
     <div class="mouse-glow" id="mouseGlow"></div>
     <div class="fixed inset-0 opacity-[0.02] parallax-layer parallax-slow" id="gridBg" style="background-image: linear-gradient(#fff 1px, transparent 1px), linear-gradient(90deg, #fff 1px, transparent 1px); background-size: 50px 50px;"></div>

--- a/services/technical-advisory.html
+++ b/services/technical-advisory.html
@@ -83,6 +83,9 @@
             --dynamic-b: 22;
             --dynamic-color: rgb(var(--dynamic-r), var(--dynamic-g), var(--dynamic-b));
             --dynamic-color-hex: #f97316;
+            --glass-frost: 0.1;
+            --glass-saturation: 1.2;
+            --filter-id: url(#glass-filter-_r_b_);
         }
         @keyframes pulse-glow { 0%, 100% { opacity: 0.4; } 50% { opacity: 0.8; } }
         @keyframes float { 0%, 100% { transform: translateY(0px); } 50% { transform: translateY(-10px); } }
@@ -161,9 +164,20 @@
             .mobile-dropdown-item:hover { color: var(--dynamic-color); }
             .mobile-dropdown-item.active { color: var(--dynamic-color); }
         }
+        /* Liquid Glass Effect */
+        .liquidglass { position: fixed; left: 50%; top: 50%; transform: translate(-50%); z-index: 1; width: 340px; background: hsl(0 0% 0% / var(--glass-frost, 0)); -webkit-backdrop-filter: var(--filter-id, url(#glass-filter)) saturate(var(--glass-saturation, 1)); backdrop-filter: var(--filter-id, url(#glass-filter)) saturate(var(--glass-saturation, 1)); box-shadow: inset 0 0 2px 1px #ffffff59, inset 0 0 10px 4px #ffffff26, inset 0 4px 16px #11111a0d, inset 0 8px 24px #11111a0d, inset 0 6px 56px #11111a0d; box-shadow: inset 0 0 2px 1px lab(100% 0 0 / .35), inset 0 0 10px 4px lab(100% 0 0 / .15), inset 0 4px 16px lab(5.32203% 1.61424 -5.88284 / .0509804), inset 0 8px 24px lab(5.32203% 1.61424 -5.88284 / .0509804), inset 0 6px 56px lab(5.32203% 1.61424 -5.88284 / .0509804); border-radius: 9999px; height: 140px; pointer-events: none; }
+        .glass-surface__filter { pointer-events: none; opacity: 0; z-index: -1; width: 100%; height: 100%; position: absolute; inset: 0; }
     </style>
 </head>
 <body class="bg-fi-black min-h-screen font-sans antialiased overflow-x-hidden">
+    <!-- Liquid Glass SVG Filter -->
+    <svg class="glass-surface__filter" aria-hidden="true">
+        <filter id="glass-filter-_r_b_" x="-50%" y="-50%" width="200%" height="200%" color-interpolation-filters="sRGB">
+            <feGaussianBlur in="SourceGraphic" stdDeviation="10" />
+        </filter>
+    </svg>
+    <!-- Liquid Glass Element -->
+    <div class="liquidglass"></div>
     <canvas id="threeCanvas" style="position: fixed; top: 0; left: 0; width: 100%; height: 100%; z-index: 0; pointer-events: none;"></canvas>
     <div class="mouse-glow" id="mouseGlow"></div>
     <div class="fixed inset-0 opacity-[0.02] parallax-layer parallax-slow" id="gridBg" style="background-image: linear-gradient(#fff 1px, transparent 1px), linear-gradient(90deg, #fff 1px, transparent 1px); background-size: 50px 50px;"></div>


### PR DESCRIPTION
## Description

Adds a decorative liquid glass effect to all pages using CSS backdrop filters and SVG Gaussian blur. This includes CSS custom properties for controlling the effect's frost level and saturation, along with an SVG filter definition and a fixed-position glass element.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Changes Made

- Added three CSS custom properties to control the glass effect:
  - `--glass-frost`: Controls the opacity/frost level (0.1)
  - `--glass-saturation`: Controls color saturation of the blur effect (1.2)
  - `--filter-id`: References the SVG filter definition
- Added `.liquidglass` class with fixed positioning, backdrop filters, and inset box-shadow styling for a frosted glass appearance
- Added `.glass-surface__filter` class for the SVG filter container
- Added SVG filter element with Gaussian blur (stdDeviation="10") to all pages
- Added fixed-position `.liquidglass` div element to all pages (index.html, contact.html, partners.html, past-performance.html, and all service pages)

## Testing

- [x] Tested locally in browser
- [x] Tested on mobile viewport

The effect is purely visual and non-interactive (pointer-events: none), so it doesn't affect page functionality or user interactions.

## Checklist

- [x] My changes follow the project's code style
- [x] I have tested my changes locally
- [x] My changes don't break existing functionality

https://claude.ai/code/session_01LZwVL1MwGXrbgLnKScWKDP