### PR TITLE
Improve text contrast by changing neutral gray text to white

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -208,15 +208,15 @@
                         <div class="dropdown-menu">
                             <a href="/services/software-engineering.html" class="dropdown-item">
                                 <div class="font-medium text-white mb-1">Software Engineering</div>
-                                <div class="text-sm text-neutral-500">Custom software solutions for federal needs</div>
+                                <div class="text-sm text-white">Custom software solutions for federal needs</div>
                             </a>
                             <a href="/services/ai-systems.html" class="dropdown-item">
                                 <div class="font-medium text-white mb-1">AI Systems & Enablement</div>
-                                <div class="text-sm text-neutral-500">AI strategy, implementation & optimization</div>
+                                <div class="text-sm text-white">AI strategy, implementation & optimization</div>
                             </a>
                             <a href="/services/technical-advisory.html" class="dropdown-item">
                                 <div class="font-medium text-white mb-1">Technical Advisory</div>
-                                <div class="text-sm text-neutral-500">Software, AI & GovCon guidance</div>
+                                <div class="text-sm text-white">Software, AI & GovCon guidance</div>
                             </a>
                         </div>
                     </div>
@@ -258,7 +258,7 @@
                         <svg class="w-5 h-5 text-dynamic-accent" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/>
                         </svg>
-                        <span class="text-sm text-neutral-400 font-medium tracking-wide uppercase">Get in Touch</span>
+                        <span class="text-sm text-white font-medium tracking-wide uppercase">Get in Touch</span>
                     </div>
                     <h1 class="text-4xl md:text-6xl lg:text-7xl font-bold tracking-tight mb-6 reveal reveal-delay-1">
                         <span class="gradient-text">Contact</span>
@@ -266,7 +266,7 @@
                         <span class="text-white">Us</span>
                     </h1>
                     <div class="w-24 h-1 glow-line shimmer-line mx-auto mb-8 rounded-full reveal reveal-delay-2"></div>
-                    <p class="text-lg md:text-xl text-neutral-400 max-w-3xl mx-auto leading-relaxed reveal reveal-delay-2">
+                    <p class="text-lg md:text-xl text-white max-w-3xl mx-auto leading-relaxed reveal reveal-delay-2">
                         Ready to accelerate your mission? Let's start a conversation about how we can help.
                     </p>
                 </div>
@@ -333,7 +333,7 @@
                                     </div>
                                     <div>
                                         <h3 class="text-white font-medium mb-1">Email</h3>
-                                        <a href="mailto:contact@federalinnovations.com" class="text-neutral-400 hover:text-dynamic-accent transition-colors">contact@federalinnovations.com</a>
+                                        <a href="mailto:contact@federalinnovations.com" class="text-white hover:text-dynamic-accent transition-colors">contact@federalinnovations.com</a>
                                     </div>
                                 </div>
                                 <div class="flex items-start gap-4">
@@ -345,7 +345,7 @@
                                     </div>
                                     <div>
                                         <h3 class="text-white font-medium mb-1">Location</h3>
-                                        <p class="text-neutral-400">Washington, D.C. Metro Area</p>
+                                        <p class="text-white">Washington, D.C. Metro Area</p>
                                     </div>
                                 </div>
                                 <div class="flex items-start gap-4">
@@ -356,7 +356,7 @@
                                     </div>
                                     <div>
                                         <h3 class="text-white font-medium mb-1">Response Time</h3>
-                                        <p class="text-neutral-400">We typically respond within 1 business day</p>
+                                        <p class="text-white">We typically respond within 1 business day</p>
                                     </div>
                                 </div>
                             </div>
@@ -365,25 +365,25 @@
                         <div class="p-8 bg-fi-gray/30 border border-white/5 rounded-2xl backdrop-blur-sm">
                             <h3 class="text-xl font-semibold text-white mb-4">Quick Links</h3>
                             <div class="space-y-3">
-                                <a href="/services/software-engineering.html" class="flex items-center gap-3 text-neutral-400 hover:text-white transition-colors">
+                                <a href="/services/software-engineering.html" class="flex items-center gap-3 text-white hover:text-white transition-colors">
                                     <svg class="w-5 h-5 text-dynamic-accent" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/>
                                     </svg>
                                     Software Engineering Services
                                 </a>
-                                <a href="/services/ai-systems.html" class="flex items-center gap-3 text-neutral-400 hover:text-white transition-colors">
+                                <a href="/services/ai-systems.html" class="flex items-center gap-3 text-white hover:text-white transition-colors">
                                     <svg class="w-5 h-5 text-dynamic-accent" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/>
                                     </svg>
                                     AI Systems & Enablement
                                 </a>
-                                <a href="/services/technical-advisory.html" class="flex items-center gap-3 text-neutral-400 hover:text-white transition-colors">
+                                <a href="/services/technical-advisory.html" class="flex items-center gap-3 text-white hover:text-white transition-colors">
                                     <svg class="w-5 h-5 text-dynamic-accent" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/>
                                     </svg>
                                     Technical Advisory
                                 </a>
-                                <a href="/past-performance.html" class="flex items-center gap-3 text-neutral-400 hover:text-white transition-colors">
+                                <a href="/past-performance.html" class="flex items-center gap-3 text-white hover:text-white transition-colors">
                                     <svg class="w-5 h-5 text-dynamic-accent" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/>
                                     </svg>
@@ -398,10 +398,10 @@
 
         <footer class="py-8 px-6 md:px-12 lg:px-20 border-t border-white/5">
             <div class="flex flex-col md:flex-row items-center justify-between gap-4">
-                <p class="text-neutral-600 text-sm">&copy; 2026 Federal Innovations. All rights reserved.</p>
-                <div class="flex items-center space-x-1 text-neutral-600 text-sm">
+                <p class="text-white text-sm">&copy; 2026 Federal Innovations. All rights reserved.</p>
+                <div class="flex items-center space-x-1 text-white text-sm">
                     <span>Washington, D.C.</span>
-                    <span class="text-neutral-700">|</span>
+                    <span class="text-white">|</span>
                     <span>Empowering government contractors</span>
                 </div>
             </div>

--- a/example/bg.css
+++ b/example/bg.css
@@ -5,7 +5,7 @@
     --color-body: #101010;
     --color-selection-bg: rgba(120, 120, 120, 0.2);
     --color-selection-text: #fff;
-    --color-text-primary: #dddddd;
+    --color-text-primary: #ffffff;
     --color-transparency-primary: rgba(20, 20, 20, 0.4);
     --color-transparency-secondary: rgba(20, 20, 20, 0.5);
     --border-radius-large: 16px;

--- a/index.html
+++ b/index.html
@@ -502,15 +502,15 @@
                         <div class="dropdown-menu">
                             <a href="/services/software-engineering.html" data-href="/software-engineering" data-page="software-engineering" class="dropdown-item">
                                 <div class="font-medium text-white mb-1">Software Engineering</div>
-                                <div class="text-sm text-neutral-500">Custom software solutions for federal needs</div>
+                                <div class="text-sm text-white">Custom software solutions for federal needs</div>
                             </a>
                             <a href="/services/ai-systems.html" data-href="/ai-systems" data-page="ai-systems" class="dropdown-item">
                                 <div class="font-medium text-white mb-1">AI Systems & Enablement</div>
-                                <div class="text-sm text-neutral-500">AI strategy, implementation & optimization</div>
+                                <div class="text-sm text-white">AI strategy, implementation & optimization</div>
                             </a>
                             <a href="/services/technical-advisory.html" data-href="/technical-advisory" data-page="technical-advisory" class="dropdown-item">
                                 <div class="font-medium text-white mb-1">Technical Advisory</div>
-                                <div class="text-sm text-neutral-500">Software, AI & GovCon guidance</div>
+                                <div class="text-sm text-white">Software, AI & GovCon guidance</div>
                             </a>
                         </div>
                     </div>
@@ -561,12 +561,12 @@
         <!-- Footer -->
         <footer class="py-8 px-6 md:px-12 lg:px-20 border-t border-white/5">
             <div class="flex flex-col md:flex-row items-center justify-between gap-4">
-                <p class="text-neutral-600 text-sm">
+                <p class="text-white text-sm">
                     &copy; 2026 Federal Innovations. All rights reserved.
                 </p>
-                <div class="flex items-center space-x-1 text-neutral-600 text-sm">
+                <div class="flex items-center space-x-1 text-white text-sm">
                     <span>Washington, D.C.</span>
-                    <span class="text-neutral-700">|</span>
+                    <span class="text-white">|</span>
                     <span>Empowering government contractors</span>
                 </div>
             </div>

--- a/pages/ai-systems.html
+++ b/pages/ai-systems.html
@@ -5,7 +5,7 @@
                         <svg class="w-5 h-5 text-dynamic-accent" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/>
                         </svg>
-                        <span class="text-sm text-neutral-400 font-medium tracking-wide uppercase">Services</span>
+                        <span class="text-sm text-white font-medium tracking-wide uppercase">Services</span>
                     </div>
                     <h1 class="text-4xl md:text-6xl lg:text-7xl font-bold tracking-tight mb-6 reveal reveal-delay-1">
                         <span class="gradient-text">AI Systems</span>
@@ -13,9 +13,9 @@
                         <span class="text-white">& Enablement</span>
                     </h1>
                     <div class="w-24 h-1 glow-line shimmer-line mx-auto mb-8 rounded-full reveal reveal-delay-2"></div>
-                    <p class="text-lg md:text-xl text-neutral-400 max-w-3xl mx-auto leading-relaxed reveal reveal-delay-2">
+                    <p class="text-lg md:text-xl text-white max-w-3xl mx-auto leading-relaxed reveal reveal-delay-2">
                         Strategic AI implementation and optimization for federal agencies.
-                        <span class="text-neutral-300">From strategy to deployment, we help you harness the power of artificial intelligence responsibly.</span>
+                        <span class="text-white">From strategy to deployment, we help you harness the power of artificial intelligence responsibly.</span>
                     </p>
                 </div>
 
@@ -28,7 +28,7 @@
                             </svg>
                         </div>
                         <h3 class="text-xl font-semibold text-white mb-3">AI Strategy & Roadmap</h3>
-                        <p class="text-neutral-400 leading-relaxed">Develop comprehensive AI adoption strategies aligned with your mission. We identify high-impact use cases and create actionable implementation roadmaps.</p>
+                        <p class="text-white leading-relaxed">Develop comprehensive AI adoption strategies aligned with your mission. We identify high-impact use cases and create actionable implementation roadmaps.</p>
                     </div>
 
                     <div class="parallax-card reveal reveal-delay-2 group p-8 bg-fi-gray/30 border border-white/5 rounded-2xl backdrop-blur-sm hover:border-dynamic-accent-30 transition-all duration-300" data-tilt>
@@ -38,7 +38,7 @@
                             </svg>
                         </div>
                         <h3 class="text-xl font-semibold text-white mb-3">ML/AI Development</h3>
-                        <p class="text-neutral-400 leading-relaxed">Custom machine learning models and AI solutions built for your specific needs. From NLP to computer vision, we develop and deploy production-ready systems.</p>
+                        <p class="text-white leading-relaxed">Custom machine learning models and AI solutions built for your specific needs. From NLP to computer vision, we develop and deploy production-ready systems.</p>
                     </div>
 
                     <div class="parallax-card reveal reveal-delay-3 group p-8 bg-fi-gray/30 border border-white/5 rounded-2xl backdrop-blur-sm hover:border-dynamic-accent-30 transition-all duration-300" data-tilt>
@@ -48,7 +48,7 @@
                             </svg>
                         </div>
                         <h3 class="text-xl font-semibold text-white mb-3">LLM Integration</h3>
-                        <p class="text-neutral-400 leading-relaxed">Integrate large language models into your workflows responsibly. We help you leverage GPT, Claude, and other LLMs while maintaining security and compliance.</p>
+                        <p class="text-white leading-relaxed">Integrate large language models into your workflows responsibly. We help you leverage GPT, Claude, and other LLMs while maintaining security and compliance.</p>
                     </div>
 
                     <div class="parallax-card reveal reveal-delay-4 group p-8 bg-fi-gray/30 border border-white/5 rounded-2xl backdrop-blur-sm hover:border-dynamic-accent-30 transition-all duration-300" data-tilt>
@@ -58,7 +58,7 @@
                             </svg>
                         </div>
                         <h3 class="text-xl font-semibold text-white mb-3">Responsible AI</h3>
-                        <p class="text-neutral-400 leading-relaxed">Implement AI governance frameworks, bias detection, and explainability. We ensure your AI systems are ethical, transparent, and aligned with federal guidelines.</p>
+                        <p class="text-white leading-relaxed">Implement AI governance frameworks, bias detection, and explainability. We ensure your AI systems are ethical, transparent, and aligned with federal guidelines.</p>
                     </div>
                 </div>
 
@@ -71,28 +71,28 @@
                                 <span class="text-dynamic-accent font-bold text-lg">1</span>
                             </div>
                             <h4 class="text-white font-medium mb-2">Assess</h4>
-                            <p class="text-neutral-500 text-sm">Evaluate current capabilities and identify AI opportunities</p>
+                            <p class="text-white text-sm">Evaluate current capabilities and identify AI opportunities</p>
                         </div>
                         <div class="text-center p-6">
                             <div class="w-12 h-12 bg-dynamic-accent-10 rounded-full flex items-center justify-center mx-auto mb-4">
                                 <span class="text-dynamic-accent font-bold text-lg">2</span>
                             </div>
                             <h4 class="text-white font-medium mb-2">Design</h4>
-                            <p class="text-neutral-500 text-sm">Architect solutions that fit your infrastructure and requirements</p>
+                            <p class="text-white text-sm">Architect solutions that fit your infrastructure and requirements</p>
                         </div>
                         <div class="text-center p-6">
                             <div class="w-12 h-12 bg-dynamic-accent-10 rounded-full flex items-center justify-center mx-auto mb-4">
                                 <span class="text-dynamic-accent font-bold text-lg">3</span>
                             </div>
                             <h4 class="text-white font-medium mb-2">Implement</h4>
-                            <p class="text-neutral-500 text-sm">Build, test, and deploy AI solutions with continuous validation</p>
+                            <p class="text-white text-sm">Build, test, and deploy AI solutions with continuous validation</p>
                         </div>
                         <div class="text-center p-6">
                             <div class="w-12 h-12 bg-dynamic-accent-10 rounded-full flex items-center justify-center mx-auto mb-4">
                                 <span class="text-dynamic-accent font-bold text-lg">4</span>
                             </div>
                             <h4 class="text-white font-medium mb-2">Optimize</h4>
-                            <p class="text-neutral-500 text-sm">Monitor performance and continuously improve model accuracy</p>
+                            <p class="text-white text-sm">Monitor performance and continuously improve model accuracy</p>
                         </div>
                     </div>
                 </div>
@@ -101,7 +101,7 @@
                 <div class="text-center reveal">
                     <div class="inline-block p-8 bg-fi-gray/30 border border-white/5 rounded-2xl backdrop-blur-sm">
                         <h2 class="text-2xl font-semibold text-white mb-4">Ready to Transform with AI?</h2>
-                        <p class="text-neutral-400 mb-6 max-w-lg">Let's explore how AI can enhance your agency's capabilities while maintaining security and compliance.</p>
+                        <p class="text-white mb-6 max-w-lg">Let's explore how AI can enhance your agency's capabilities while maintaining security and compliance.</p>
                         <a href="/contact.html" class="btn-glass group inline-flex items-center space-x-2 text-white font-semibold px-8 py-4 rounded-xl transition-all duration-300">
                             <span>Start the Conversation</span>
                             <svg class="w-5 h-5 group-hover:translate-x-1 transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/pages/contact.html
+++ b/pages/contact.html
@@ -24,7 +24,7 @@
                         <svg class="w-5 h-5 text-dynamic-accent" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/>
                         </svg>
-                        <span class="text-sm text-neutral-400 font-medium tracking-wide uppercase">Get in Touch</span>
+                        <span class="text-sm text-white font-medium tracking-wide uppercase">Get in Touch</span>
                     </div>
                     <h1 class="text-4xl md:text-6xl lg:text-7xl font-bold tracking-tight mb-6 reveal reveal-delay-1">
                         <span class="gradient-text">Contact</span>
@@ -32,7 +32,7 @@
                         <span class="text-white">Us</span>
                     </h1>
                     <div class="w-24 h-1 glow-line shimmer-line mx-auto mb-8 rounded-full reveal reveal-delay-2"></div>
-                    <p class="text-lg md:text-xl text-neutral-400 max-w-3xl mx-auto leading-relaxed reveal reveal-delay-2">
+                    <p class="text-lg md:text-xl text-white max-w-3xl mx-auto leading-relaxed reveal reveal-delay-2">
                         Ready to accelerate your mission? Let's start a conversation about how we can help.
                     </p>
                 </div>
@@ -99,7 +99,7 @@
                                     </div>
                                     <div>
                                         <h3 class="text-white font-medium mb-1">Email</h3>
-                                        <a href="mailto:contact@federalinnovations.com" class="text-neutral-400 hover:text-dynamic-accent transition-colors">contact@federalinnovations.com</a>
+                                        <a href="mailto:contact@federalinnovations.com" class="text-white hover:text-dynamic-accent transition-colors">contact@federalinnovations.com</a>
                                     </div>
                                 </div>
                                 <div class="flex items-start gap-4">
@@ -111,7 +111,7 @@
                                     </div>
                                     <div>
                                         <h3 class="text-white font-medium mb-1">Location</h3>
-                                        <p class="text-neutral-400">Washington, D.C. Metro Area</p>
+                                        <p class="text-white">Washington, D.C. Metro Area</p>
                                     </div>
                                 </div>
                                 <div class="flex items-start gap-4">
@@ -122,7 +122,7 @@
                                     </div>
                                     <div>
                                         <h3 class="text-white font-medium mb-1">Response Time</h3>
-                                        <p class="text-neutral-400">We typically respond within 1 business day</p>
+                                        <p class="text-white">We typically respond within 1 business day</p>
                                     </div>
                                 </div>
                             </div>
@@ -131,25 +131,25 @@
                         <div class="p-8 bg-fi-gray/30 border border-white/5 rounded-2xl backdrop-blur-sm">
                             <h3 class="text-xl font-semibold text-white mb-4">Quick Links</h3>
                             <div class="space-y-3">
-                                <a href="/services/software-engineering.html" class="flex items-center gap-3 text-neutral-400 hover:text-white transition-colors">
+                                <a href="/services/software-engineering.html" class="flex items-center gap-3 text-white hover:text-white transition-colors">
                                     <svg class="w-5 h-5 text-dynamic-accent" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/>
                                     </svg>
                                     Software Engineering Services
                                 </a>
-                                <a href="/services/ai-systems.html" class="flex items-center gap-3 text-neutral-400 hover:text-white transition-colors">
+                                <a href="/services/ai-systems.html" class="flex items-center gap-3 text-white hover:text-white transition-colors">
                                     <svg class="w-5 h-5 text-dynamic-accent" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/>
                                     </svg>
                                     AI Systems & Enablement
                                 </a>
-                                <a href="/services/technical-advisory.html" class="flex items-center gap-3 text-neutral-400 hover:text-white transition-colors">
+                                <a href="/services/technical-advisory.html" class="flex items-center gap-3 text-white hover:text-white transition-colors">
                                     <svg class="w-5 h-5 text-dynamic-accent" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/>
                                     </svg>
                                     Technical Advisory
                                 </a>
-                                <a href="/past-performance.html" class="flex items-center gap-3 text-neutral-400 hover:text-white transition-colors">
+                                <a href="/past-performance.html" class="flex items-center gap-3 text-white hover:text-white transition-colors">
                                     <svg class="w-5 h-5 text-dynamic-accent" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/>
                                     </svg>

--- a/pages/home.html
+++ b/pages/home.html
@@ -2,7 +2,7 @@
                 <!-- Status badge -->
                 <div class="reveal inline-flex items-center space-x-2 bg-fi-gray/50 border border-white/10 rounded-full px-4 py-2 mb-8 backdrop-blur-sm parallax-layer" data-parallax-speed="0.6">
                     <span class="w-2 h-2 bg-dynamic-accent rounded-full animate-pulse"></span>
-                    <span class="text-sm text-neutral-400 font-medium tracking-wide uppercase">In Development</span>
+                    <span class="text-sm text-white font-medium tracking-wide uppercase">In Development</span>
                 </div>
 
                 <!-- Main heading -->
@@ -16,9 +16,9 @@
                 <div class="w-24 h-1 glow-line shimmer-line mx-auto mb-8 rounded-full reveal reveal-delay-2"></div>
 
                 <!-- Subheading -->
-                <p class="text-lg md:text-xl text-neutral-400 max-w-2xl mx-auto mb-12 leading-relaxed reveal reveal-delay-2 parallax-layer" data-parallax-speed="0.5">
+                <p class="text-lg md:text-xl text-white max-w-2xl mx-auto mb-12 leading-relaxed reveal reveal-delay-2 parallax-layer" data-parallax-speed="0.5">
                     Strategic consulting and staffing solutions for government contractors.
-                    <span class="text-neutral-300">Accelerating growth in the federal marketplace.</span>
+                    <span class="text-white">Accelerating growth in the federal marketplace.</span>
                 </p>
 
                 <!-- Feature hints -->
@@ -30,7 +30,7 @@
                             </svg>
                         </div>
                         <h3 class="text-white font-semibold mb-2">Software Development</h3>
-                        <p class="text-neutral-500 text-sm">Custom software solutions for federal agencies and contractors</p>
+                        <p class="text-white text-sm">Custom software solutions for federal agencies and contractors</p>
                     </div>
 
                     <div class="parallax-card reveal reveal-delay-2 group p-6 bg-fi-gray/30 border border-white/5 rounded-2xl backdrop-blur-sm hover:border-dynamic-accent-30 transition-all duration-300" data-tilt>
@@ -40,7 +40,7 @@
                             </svg>
                         </div>
                         <h3 class="text-white font-semibold mb-2">AI Modernization & Optimization</h3>
-                        <p class="text-neutral-500 text-sm">AI strategy, implementation, and performance optimization</p>
+                        <p class="text-white text-sm">AI strategy, implementation, and performance optimization</p>
                     </div>
 
                     <div class="parallax-card reveal reveal-delay-3 group p-6 bg-fi-gray/30 border border-white/5 rounded-2xl backdrop-blur-sm hover:border-dynamic-accent-30 transition-all duration-300" data-tilt>
@@ -50,7 +50,7 @@
                             </svg>
                         </div>
                         <h3 class="text-white font-semibold mb-2">Government Contracting Advisory</h3>
-                        <p class="text-neutral-500 text-sm">Strategic guidance for navigating the federal marketplace</p>
+                        <p class="text-white text-sm">Strategic guidance for navigating the federal marketplace</p>
                     </div>
                 </div>
 
@@ -64,7 +64,7 @@
                         </svg>
                     </a>
                     <a href="mailto:contact@federalinnovations.com"
-                       class="inline-flex items-center space-x-2 text-neutral-400 hover:text-white font-medium px-6 py-4 transition-colors duration-300">
+                       class="inline-flex items-center space-x-2 text-white hover:text-white font-medium px-6 py-4 transition-colors duration-300">
                         <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/>
                         </svg>

--- a/pages/partners.html
+++ b/pages/partners.html
@@ -5,7 +5,7 @@
                         <svg class="w-5 h-5 text-dynamic-accent" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z"/>
                         </svg>
-                        <span class="text-sm text-neutral-400 font-medium tracking-wide uppercase">Ecosystem</span>
+                        <span class="text-sm text-white font-medium tracking-wide uppercase">Ecosystem</span>
                     </div>
                     <h1 class="text-4xl md:text-6xl lg:text-7xl font-bold tracking-tight mb-6 reveal reveal-delay-1">
                         <span class="gradient-text">Our</span>
@@ -13,9 +13,9 @@
                         <span class="text-white">Partners</span>
                     </h1>
                     <div class="w-24 h-1 glow-line shimmer-line mx-auto mb-8 rounded-full reveal reveal-delay-2"></div>
-                    <p class="text-lg md:text-xl text-neutral-400 max-w-3xl mx-auto leading-relaxed reveal reveal-delay-2">
+                    <p class="text-lg md:text-xl text-white max-w-3xl mx-auto leading-relaxed reveal reveal-delay-2">
                         Strategic partnerships that amplify our capabilities and expand our reach.
-                        <span class="text-neutral-300">Together, we deliver exceptional value to the federal market.</span>
+                        <span class="text-white">Together, we deliver exceptional value to the federal market.</span>
                     </p>
                 </div>
 
@@ -30,7 +30,7 @@
                                 </svg>
                             </div>
                             <h3 class="text-xl font-semibold text-white mb-3">AWS</h3>
-                            <p class="text-neutral-400 text-sm">AWS Partner Network member with expertise in GovCloud deployments and FedRAMP-compliant architectures.</p>
+                            <p class="text-white text-sm">AWS Partner Network member with expertise in GovCloud deployments and FedRAMP-compliant architectures.</p>
                         </div>
 
                         <div class="parallax-card reveal reveal-delay-2 group p-8 bg-fi-gray/30 border border-white/5 rounded-2xl backdrop-blur-sm hover:border-dynamic-accent-30 transition-all duration-300 text-center" data-tilt>
@@ -40,7 +40,7 @@
                                 </svg>
                             </div>
                             <h3 class="text-xl font-semibold text-white mb-3">Microsoft Azure</h3>
-                            <p class="text-neutral-400 text-sm">Microsoft Partner with deep experience in Azure Government and hybrid cloud solutions for federal agencies.</p>
+                            <p class="text-white text-sm">Microsoft Partner with deep experience in Azure Government and hybrid cloud solutions for federal agencies.</p>
                         </div>
 
                         <div class="parallax-card reveal reveal-delay-3 group p-8 bg-fi-gray/30 border border-white/5 rounded-2xl backdrop-blur-sm hover:border-dynamic-accent-30 transition-all duration-300 text-center" data-tilt>
@@ -50,7 +50,7 @@
                                 </svg>
                             </div>
                             <h3 class="text-xl font-semibold text-white mb-3">Snowflake</h3>
-                            <p class="text-neutral-400 text-sm">Snowflake partner delivering scalable data warehouse solutions for federal data analytics needs.</p>
+                            <p class="text-white text-sm">Snowflake partner delivering scalable data warehouse solutions for federal data analytics needs.</p>
                         </div>
                     </div>
                 </div>
@@ -67,25 +67,25 @@
                                         <svg class="w-5 h-5 text-dynamic-accent flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
                                         </svg>
-                                        <span class="text-neutral-400">Deep technical expertise in software development and AI</span>
+                                        <span class="text-white">Deep technical expertise in software development and AI</span>
                                     </li>
                                     <li class="flex items-start gap-3">
                                         <svg class="w-5 h-5 text-dynamic-accent flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
                                         </svg>
-                                        <span class="text-neutral-400">Proven past performance with federal agencies</span>
+                                        <span class="text-white">Proven past performance with federal agencies</span>
                                     </li>
                                     <li class="flex items-start gap-3">
                                         <svg class="w-5 h-5 text-dynamic-accent flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
                                         </svg>
-                                        <span class="text-neutral-400">Flexible engagement models for prime/sub arrangements</span>
+                                        <span class="text-white">Flexible engagement models for prime/sub arrangements</span>
                                     </li>
                                     <li class="flex items-start gap-3">
                                         <svg class="w-5 h-5 text-dynamic-accent flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
                                         </svg>
-                                        <span class="text-neutral-400">Commitment to long-term partnership success</span>
+                                        <span class="text-white">Commitment to long-term partnership success</span>
                                     </li>
                                 </ul>
                             </div>
@@ -96,25 +96,25 @@
                                         <svg class="w-5 h-5 text-dynamic-accent flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
                                         </svg>
-                                        <span class="text-neutral-400">Prime contractors seeking technical expertise</span>
+                                        <span class="text-white">Prime contractors seeking technical expertise</span>
                                     </li>
                                     <li class="flex items-start gap-3">
                                         <svg class="w-5 h-5 text-dynamic-accent flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
                                         </svg>
-                                        <span class="text-neutral-400">Small businesses with complementary capabilities</span>
+                                        <span class="text-white">Small businesses with complementary capabilities</span>
                                     </li>
                                     <li class="flex items-start gap-3">
                                         <svg class="w-5 h-5 text-dynamic-accent flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
                                         </svg>
-                                        <span class="text-neutral-400">Technology vendors expanding into federal</span>
+                                        <span class="text-white">Technology vendors expanding into federal</span>
                                     </li>
                                     <li class="flex items-start gap-3">
                                         <svg class="w-5 h-5 text-dynamic-accent flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
                                         </svg>
-                                        <span class="text-neutral-400">Organizations pursuing specific contract vehicles</span>
+                                        <span class="text-white">Organizations pursuing specific contract vehicles</span>
                                     </li>
                                 </ul>
                             </div>
@@ -126,7 +126,7 @@
                 <div class="text-center reveal">
                     <div class="inline-block p-8 bg-fi-gray/30 border border-white/5 rounded-2xl backdrop-blur-sm">
                         <h2 class="text-2xl font-semibold text-white mb-4">Interested in Partnering?</h2>
-                        <p class="text-neutral-400 mb-6 max-w-lg">We're always looking for strategic partners who share our commitment to excellence. Let's explore how we can work together.</p>
+                        <p class="text-white mb-6 max-w-lg">We're always looking for strategic partners who share our commitment to excellence. Let's explore how we can work together.</p>
                         <a href="/contact.html" class="btn-glass group inline-flex items-center space-x-2 text-white font-semibold px-8 py-4 rounded-xl transition-all duration-300">
                             <span>Discuss Partnership</span>
                             <svg class="w-5 h-5 group-hover:translate-x-1 transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/pages/past-performance.html
+++ b/pages/past-performance.html
@@ -5,7 +5,7 @@
                         <svg class="w-5 h-5 text-dynamic-accent" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M9 12l2 2 4-4M7.835 4.697a3.42 3.42 0 001.946-.806 3.42 3.42 0 014.438 0 3.42 3.42 0 001.946.806 3.42 3.42 0 013.138 3.138 3.42 3.42 0 00.806 1.946 3.42 3.42 0 010 4.438 3.42 3.42 0 00-.806 1.946 3.42 3.42 0 01-3.138 3.138 3.42 3.42 0 00-1.946.806 3.42 3.42 0 01-4.438 0 3.42 3.42 0 00-1.946-.806 3.42 3.42 0 01-3.138-3.138 3.42 3.42 0 00-.806-1.946 3.42 3.42 0 010-4.438 3.42 3.42 0 00.806-1.946 3.42 3.42 0 013.138-3.138z"/>
                         </svg>
-                        <span class="text-sm text-neutral-400 font-medium tracking-wide uppercase">Track Record</span>
+                        <span class="text-sm text-white font-medium tracking-wide uppercase">Track Record</span>
                     </div>
                     <h1 class="text-4xl md:text-6xl lg:text-7xl font-bold tracking-tight mb-6 reveal reveal-delay-1">
                         <span class="gradient-text">Past</span>
@@ -13,9 +13,9 @@
                         <span class="text-white">Performance</span>
                     </h1>
                     <div class="w-24 h-1 glow-line shimmer-line mx-auto mb-8 rounded-full reveal reveal-delay-2"></div>
-                    <p class="text-lg md:text-xl text-neutral-400 max-w-3xl mx-auto leading-relaxed reveal reveal-delay-2">
+                    <p class="text-lg md:text-xl text-white max-w-3xl mx-auto leading-relaxed reveal reveal-delay-2">
                         A proven track record of delivering mission-critical solutions for federal agencies and government contractors.
-                        <span class="text-neutral-300">Results that speak for themselves.</span>
+                        <span class="text-white">Results that speak for themselves.</span>
                     </p>
                 </div>
 
@@ -23,19 +23,19 @@
                 <div class="grid grid-cols-2 md:grid-cols-4 gap-6 mb-16 reveal">
                     <div class="text-center p-6 bg-fi-gray/30 border border-white/5 rounded-2xl backdrop-blur-sm">
                         <div class="text-3xl md:text-4xl font-bold text-dynamic-accent mb-2">15+</div>
-                        <div class="text-neutral-400 text-sm">Federal Projects</div>
+                        <div class="text-white text-sm">Federal Projects</div>
                     </div>
                     <div class="text-center p-6 bg-fi-gray/30 border border-white/5 rounded-2xl backdrop-blur-sm">
                         <div class="text-3xl md:text-4xl font-bold text-dynamic-accent mb-2">100%</div>
-                        <div class="text-neutral-400 text-sm">On-Time Delivery</div>
+                        <div class="text-white text-sm">On-Time Delivery</div>
                     </div>
                     <div class="text-center p-6 bg-fi-gray/30 border border-white/5 rounded-2xl backdrop-blur-sm">
                         <div class="text-3xl md:text-4xl font-bold text-dynamic-accent mb-2">8+</div>
-                        <div class="text-neutral-400 text-sm">Agency Partners</div>
+                        <div class="text-white text-sm">Agency Partners</div>
                     </div>
                     <div class="text-center p-6 bg-fi-gray/30 border border-white/5 rounded-2xl backdrop-blur-sm">
                         <div class="text-3xl md:text-4xl font-bold text-dynamic-accent mb-2">5</div>
-                        <div class="text-neutral-400 text-sm">Years Experience</div>
+                        <div class="text-white text-sm">Years Experience</div>
                     </div>
                 </div>
 
@@ -55,11 +55,11 @@
                                     <h3 class="text-xl font-semibold text-white">Enterprise Security Platform Modernization</h3>
                                     <span class="px-3 py-1 bg-dynamic-accent-10 rounded-full text-xs text-dynamic-accent font-medium">Defense</span>
                                 </div>
-                                <p class="text-neutral-400 mb-4">Led the modernization of a legacy security monitoring platform serving 50,000+ users. Migrated to cloud-native architecture on AWS GovCloud while maintaining FedRAMP High authorization.</p>
+                                <p class="text-white mb-4">Led the modernization of a legacy security monitoring platform serving 50,000+ users. Migrated to cloud-native architecture on AWS GovCloud while maintaining FedRAMP High authorization.</p>
                                 <div class="flex flex-wrap gap-2">
-                                    <span class="px-3 py-1 bg-fi-dark rounded-lg text-xs text-neutral-400">AWS GovCloud</span>
-                                    <span class="px-3 py-1 bg-fi-dark rounded-lg text-xs text-neutral-400">Kubernetes</span>
-                                    <span class="px-3 py-1 bg-fi-dark rounded-lg text-xs text-neutral-400">FedRAMP High</span>
+                                    <span class="px-3 py-1 bg-fi-dark rounded-lg text-xs text-white">AWS GovCloud</span>
+                                    <span class="px-3 py-1 bg-fi-dark rounded-lg text-xs text-white">Kubernetes</span>
+                                    <span class="px-3 py-1 bg-fi-dark rounded-lg text-xs text-white">FedRAMP High</span>
                                 </div>
                             </div>
                         </div>
@@ -77,11 +77,11 @@
                                     <h3 class="text-xl font-semibold text-white">AI-Powered Document Processing System</h3>
                                     <span class="px-3 py-1 bg-dynamic-accent-10 rounded-full text-xs text-dynamic-accent font-medium">Civilian</span>
                                 </div>
-                                <p class="text-neutral-400 mb-4">Designed and implemented an AI system to automate document classification and data extraction, reducing manual processing time by 85% and improving accuracy to 99.2%.</p>
+                                <p class="text-white mb-4">Designed and implemented an AI system to automate document classification and data extraction, reducing manual processing time by 85% and improving accuracy to 99.2%.</p>
                                 <div class="flex flex-wrap gap-2">
-                                    <span class="px-3 py-1 bg-fi-dark rounded-lg text-xs text-neutral-400">Machine Learning</span>
-                                    <span class="px-3 py-1 bg-fi-dark rounded-lg text-xs text-neutral-400">NLP</span>
-                                    <span class="px-3 py-1 bg-fi-dark rounded-lg text-xs text-neutral-400">Python</span>
+                                    <span class="px-3 py-1 bg-fi-dark rounded-lg text-xs text-white">Machine Learning</span>
+                                    <span class="px-3 py-1 bg-fi-dark rounded-lg text-xs text-white">NLP</span>
+                                    <span class="px-3 py-1 bg-fi-dark rounded-lg text-xs text-white">Python</span>
                                 </div>
                             </div>
                         </div>
@@ -99,11 +99,11 @@
                                     <h3 class="text-xl font-semibold text-white">Data Analytics Platform for Health Agency</h3>
                                     <span class="px-3 py-1 bg-dynamic-accent-10 rounded-full text-xs text-dynamic-accent font-medium">Health</span>
                                 </div>
-                                <p class="text-neutral-400 mb-4">Built a comprehensive data analytics platform enabling real-time insights across multiple data sources, supporting evidence-based policy decisions affecting millions of citizens.</p>
+                                <p class="text-white mb-4">Built a comprehensive data analytics platform enabling real-time insights across multiple data sources, supporting evidence-based policy decisions affecting millions of citizens.</p>
                                 <div class="flex flex-wrap gap-2">
-                                    <span class="px-3 py-1 bg-fi-dark rounded-lg text-xs text-neutral-400">Data Engineering</span>
-                                    <span class="px-3 py-1 bg-fi-dark rounded-lg text-xs text-neutral-400">Snowflake</span>
-                                    <span class="px-3 py-1 bg-fi-dark rounded-lg text-xs text-neutral-400">Tableau</span>
+                                    <span class="px-3 py-1 bg-fi-dark rounded-lg text-xs text-white">Data Engineering</span>
+                                    <span class="px-3 py-1 bg-fi-dark rounded-lg text-xs text-white">Snowflake</span>
+                                    <span class="px-3 py-1 bg-fi-dark rounded-lg text-xs text-white">Tableau</span>
                                 </div>
                             </div>
                         </div>
@@ -114,7 +114,7 @@
                 <div class="text-center reveal">
                     <div class="inline-block p-8 bg-fi-gray/30 border border-white/5 rounded-2xl backdrop-blur-sm">
                         <h2 class="text-2xl font-semibold text-white mb-4">Ready to Add Your Success Story?</h2>
-                        <p class="text-neutral-400 mb-6 max-w-lg">Let's discuss how we can bring the same level of excellence to your next federal project.</p>
+                        <p class="text-white mb-6 max-w-lg">Let's discuss how we can bring the same level of excellence to your next federal project.</p>
                         <a href="/contact.html" class="btn-glass group inline-flex items-center space-x-2 text-white font-semibold px-8 py-4 rounded-xl transition-all duration-300">
                             <span>Start a Project</span>
                             <svg class="w-5 h-5 group-hover:translate-x-1 transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/pages/software-engineering.html
+++ b/pages/software-engineering.html
@@ -5,7 +5,7 @@
                         <svg class="w-5 h-5 text-dynamic-accent" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4"/>
                         </svg>
-                        <span class="text-sm text-neutral-400 font-medium tracking-wide uppercase">Services</span>
+                        <span class="text-sm text-white font-medium tracking-wide uppercase">Services</span>
                     </div>
                     <h1 class="text-4xl md:text-6xl lg:text-7xl font-bold tracking-tight mb-6 reveal reveal-delay-1">
                         <span class="gradient-text">Software</span>
@@ -13,9 +13,9 @@
                         <span class="text-white">Engineering</span>
                     </h1>
                     <div class="w-24 h-1 glow-line shimmer-line mx-auto mb-8 rounded-full reveal reveal-delay-2"></div>
-                    <p class="text-lg md:text-xl text-neutral-400 max-w-3xl mx-auto leading-relaxed reveal reveal-delay-2">
+                    <p class="text-lg md:text-xl text-white max-w-3xl mx-auto leading-relaxed reveal reveal-delay-2">
                         Custom software solutions designed for the unique requirements of federal agencies and government contractors.
-                        <span class="text-neutral-300">Built secure, compliant, and scalable from day one.</span>
+                        <span class="text-white">Built secure, compliant, and scalable from day one.</span>
                     </p>
                 </div>
 
@@ -28,7 +28,7 @@
                             </svg>
                         </div>
                         <h3 class="text-xl font-semibold text-white mb-3">Full-Stack Development</h3>
-                        <p class="text-neutral-400 leading-relaxed">End-to-end application development using modern frameworks and cloud-native architectures. From React frontends to microservices backends, we build systems that scale.</p>
+                        <p class="text-white leading-relaxed">End-to-end application development using modern frameworks and cloud-native architectures. From React frontends to microservices backends, we build systems that scale.</p>
                     </div>
 
                     <div class="parallax-card reveal reveal-delay-2 group p-8 bg-fi-gray/30 border border-white/5 rounded-2xl backdrop-blur-sm hover:border-dynamic-accent-30 transition-all duration-300" data-tilt>
@@ -38,7 +38,7 @@
                             </svg>
                         </div>
                         <h3 class="text-xl font-semibold text-white mb-3">Secure Development</h3>
-                        <p class="text-neutral-400 leading-relaxed">Security-first development practices aligned with NIST, FedRAMP, and FISMA requirements. Every line of code is written with compliance in mind.</p>
+                        <p class="text-white leading-relaxed">Security-first development practices aligned with NIST, FedRAMP, and FISMA requirements. Every line of code is written with compliance in mind.</p>
                     </div>
 
                     <div class="parallax-card reveal reveal-delay-3 group p-8 bg-fi-gray/30 border border-white/5 rounded-2xl backdrop-blur-sm hover:border-dynamic-accent-30 transition-all duration-300" data-tilt>
@@ -48,7 +48,7 @@
                             </svg>
                         </div>
                         <h3 class="text-xl font-semibold text-white mb-3">Cloud Migration</h3>
-                        <p class="text-neutral-400 leading-relaxed">Seamless migration to AWS GovCloud, Azure Government, or hybrid environments. We modernize legacy systems while ensuring zero downtime.</p>
+                        <p class="text-white leading-relaxed">Seamless migration to AWS GovCloud, Azure Government, or hybrid environments. We modernize legacy systems while ensuring zero downtime.</p>
                     </div>
 
                     <div class="parallax-card reveal reveal-delay-4 group p-8 bg-fi-gray/30 border border-white/5 rounded-2xl backdrop-blur-sm hover:border-dynamic-accent-30 transition-all duration-300" data-tilt>
@@ -58,7 +58,7 @@
                             </svg>
                         </div>
                         <h3 class="text-xl font-semibold text-white mb-3">Data Engineering</h3>
-                        <p class="text-neutral-400 leading-relaxed">Build robust data pipelines, warehouses, and analytics platforms. Transform raw data into actionable insights for better decision-making.</p>
+                        <p class="text-white leading-relaxed">Build robust data pipelines, warehouses, and analytics platforms. Transform raw data into actionable insights for better decision-making.</p>
                     </div>
                 </div>
 
@@ -66,18 +66,18 @@
                 <div class="reveal mb-16">
                     <h2 class="text-2xl font-semibold text-white mb-8 text-center">Technologies We Work With</h2>
                     <div class="flex flex-wrap justify-center gap-4">
-                        <span class="px-4 py-2 bg-fi-gray/50 border border-white/10 rounded-lg text-neutral-300 text-sm">Python</span>
-                        <span class="px-4 py-2 bg-fi-gray/50 border border-white/10 rounded-lg text-neutral-300 text-sm">Java</span>
-                        <span class="px-4 py-2 bg-fi-gray/50 border border-white/10 rounded-lg text-neutral-300 text-sm">TypeScript</span>
-                        <span class="px-4 py-2 bg-fi-gray/50 border border-white/10 rounded-lg text-neutral-300 text-sm">React</span>
-                        <span class="px-4 py-2 bg-fi-gray/50 border border-white/10 rounded-lg text-neutral-300 text-sm">Node.js</span>
-                        <span class="px-4 py-2 bg-fi-gray/50 border border-white/10 rounded-lg text-neutral-300 text-sm">AWS GovCloud</span>
-                        <span class="px-4 py-2 bg-fi-gray/50 border border-white/10 rounded-lg text-neutral-300 text-sm">Azure Government</span>
-                        <span class="px-4 py-2 bg-fi-gray/50 border border-white/10 rounded-lg text-neutral-300 text-sm">Kubernetes</span>
-                        <span class="px-4 py-2 bg-fi-gray/50 border border-white/10 rounded-lg text-neutral-300 text-sm">Docker</span>
-                        <span class="px-4 py-2 bg-fi-gray/50 border border-white/10 rounded-lg text-neutral-300 text-sm">PostgreSQL</span>
-                        <span class="px-4 py-2 bg-fi-gray/50 border border-white/10 rounded-lg text-neutral-300 text-sm">MongoDB</span>
-                        <span class="px-4 py-2 bg-fi-gray/50 border border-white/10 rounded-lg text-neutral-300 text-sm">Terraform</span>
+                        <span class="px-4 py-2 bg-fi-gray/50 border border-white/10 rounded-lg text-white text-sm">Python</span>
+                        <span class="px-4 py-2 bg-fi-gray/50 border border-white/10 rounded-lg text-white text-sm">Java</span>
+                        <span class="px-4 py-2 bg-fi-gray/50 border border-white/10 rounded-lg text-white text-sm">TypeScript</span>
+                        <span class="px-4 py-2 bg-fi-gray/50 border border-white/10 rounded-lg text-white text-sm">React</span>
+                        <span class="px-4 py-2 bg-fi-gray/50 border border-white/10 rounded-lg text-white text-sm">Node.js</span>
+                        <span class="px-4 py-2 bg-fi-gray/50 border border-white/10 rounded-lg text-white text-sm">AWS GovCloud</span>
+                        <span class="px-4 py-2 bg-fi-gray/50 border border-white/10 rounded-lg text-white text-sm">Azure Government</span>
+                        <span class="px-4 py-2 bg-fi-gray/50 border border-white/10 rounded-lg text-white text-sm">Kubernetes</span>
+                        <span class="px-4 py-2 bg-fi-gray/50 border border-white/10 rounded-lg text-white text-sm">Docker</span>
+                        <span class="px-4 py-2 bg-fi-gray/50 border border-white/10 rounded-lg text-white text-sm">PostgreSQL</span>
+                        <span class="px-4 py-2 bg-fi-gray/50 border border-white/10 rounded-lg text-white text-sm">MongoDB</span>
+                        <span class="px-4 py-2 bg-fi-gray/50 border border-white/10 rounded-lg text-white text-sm">Terraform</span>
                     </div>
                 </div>
 
@@ -85,7 +85,7 @@
                 <div class="text-center reveal">
                     <div class="inline-block p-8 bg-fi-gray/30 border border-white/5 rounded-2xl backdrop-blur-sm">
                         <h2 class="text-2xl font-semibold text-white mb-4">Ready to Build Something Great?</h2>
-                        <p class="text-neutral-400 mb-6 max-w-lg">Let's discuss how our software engineering expertise can help your agency or organization achieve its mission.</p>
+                        <p class="text-white mb-6 max-w-lg">Let's discuss how our software engineering expertise can help your agency or organization achieve its mission.</p>
                         <a href="/contact.html" class="btn-glass group inline-flex items-center space-x-2 text-white font-semibold px-8 py-4 rounded-xl transition-all duration-300">
                             <span>Get in Touch</span>
                             <svg class="w-5 h-5 group-hover:translate-x-1 transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/pages/technical-advisory.html
+++ b/pages/technical-advisory.html
@@ -5,7 +5,7 @@
                         <svg class="w-5 h-5 text-dynamic-accent" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4"/>
                         </svg>
-                        <span class="text-sm text-neutral-400 font-medium tracking-wide uppercase">Services</span>
+                        <span class="text-sm text-white font-medium tracking-wide uppercase">Services</span>
                     </div>
                     <h1 class="text-4xl md:text-6xl lg:text-7xl font-bold tracking-tight mb-6 reveal reveal-delay-1">
                         <span class="gradient-text">Technical</span>
@@ -13,9 +13,9 @@
                         <span class="text-white">Advisory</span>
                     </h1>
                     <div class="w-24 h-1 glow-line shimmer-line mx-auto mb-8 rounded-full reveal reveal-delay-2"></div>
-                    <p class="text-lg md:text-xl text-neutral-400 max-w-3xl mx-auto leading-relaxed reveal reveal-delay-2">
+                    <p class="text-lg md:text-xl text-white max-w-3xl mx-auto leading-relaxed reveal reveal-delay-2">
                         Expert guidance on software architecture, AI strategy, and government contracting.
-                        <span class="text-neutral-300">Strategic advice from practitioners who understand both technology and the federal marketplace.</span>
+                        <span class="text-white">Strategic advice from practitioners who understand both technology and the federal marketplace.</span>
                     </p>
                 </div>
 
@@ -28,7 +28,7 @@
                             </svg>
                         </div>
                         <h3 class="text-xl font-semibold text-white mb-3">Architecture Review</h3>
-                        <p class="text-neutral-400 leading-relaxed">Expert assessment of your software architecture with actionable recommendations for improvement, scalability, and security.</p>
+                        <p class="text-white leading-relaxed">Expert assessment of your software architecture with actionable recommendations for improvement, scalability, and security.</p>
                     </div>
 
                     <div class="parallax-card reveal reveal-delay-2 group p-8 bg-fi-gray/30 border border-white/5 rounded-2xl backdrop-blur-sm hover:border-dynamic-accent-30 transition-all duration-300" data-tilt>
@@ -38,7 +38,7 @@
                             </svg>
                         </div>
                         <h3 class="text-xl font-semibold text-white mb-3">Proposal Support</h3>
-                        <p class="text-neutral-400 leading-relaxed">Technical writing and strategy support for federal proposals. We help craft winning technical volumes that resonate with evaluators.</p>
+                        <p class="text-white leading-relaxed">Technical writing and strategy support for federal proposals. We help craft winning technical volumes that resonate with evaluators.</p>
                     </div>
 
                     <div class="parallax-card reveal reveal-delay-3 group p-8 bg-fi-gray/30 border border-white/5 rounded-2xl backdrop-blur-sm hover:border-dynamic-accent-30 transition-all duration-300" data-tilt>
@@ -48,7 +48,7 @@
                             </svg>
                         </div>
                         <h3 class="text-xl font-semibold text-white mb-3">Compliance Guidance</h3>
-                        <p class="text-neutral-400 leading-relaxed">Navigate FedRAMP, FISMA, NIST, and other federal compliance requirements with expert guidance tailored to your solutions.</p>
+                        <p class="text-white leading-relaxed">Navigate FedRAMP, FISMA, NIST, and other federal compliance requirements with expert guidance tailored to your solutions.</p>
                     </div>
 
                     <div class="parallax-card reveal reveal-delay-1 group p-8 bg-fi-gray/30 border border-white/5 rounded-2xl backdrop-blur-sm hover:border-dynamic-accent-30 transition-all duration-300" data-tilt>
@@ -58,7 +58,7 @@
                             </svg>
                         </div>
                         <h3 class="text-xl font-semibold text-white mb-3">AI Readiness Assessment</h3>
-                        <p class="text-neutral-400 leading-relaxed">Evaluate your organization's AI maturity and develop a roadmap for responsible AI adoption aligned with federal guidelines.</p>
+                        <p class="text-white leading-relaxed">Evaluate your organization's AI maturity and develop a roadmap for responsible AI adoption aligned with federal guidelines.</p>
                     </div>
 
                     <div class="parallax-card reveal reveal-delay-2 group p-8 bg-fi-gray/30 border border-white/5 rounded-2xl backdrop-blur-sm hover:border-dynamic-accent-30 transition-all duration-300" data-tilt>
@@ -68,7 +68,7 @@
                             </svg>
                         </div>
                         <h3 class="text-xl font-semibold text-white mb-3">Team Augmentation Strategy</h3>
-                        <p class="text-neutral-400 leading-relaxed">Optimize your technical staffing approach with guidance on skill gaps, hiring strategies, and team structure for federal projects.</p>
+                        <p class="text-white leading-relaxed">Optimize your technical staffing approach with guidance on skill gaps, hiring strategies, and team structure for federal projects.</p>
                     </div>
 
                     <div class="parallax-card reveal reveal-delay-3 group p-8 bg-fi-gray/30 border border-white/5 rounded-2xl backdrop-blur-sm hover:border-dynamic-accent-30 transition-all duration-300" data-tilt>
@@ -78,7 +78,7 @@
                             </svg>
                         </div>
                         <h3 class="text-xl font-semibold text-white mb-3">GovCon Strategy</h3>
-                        <p class="text-neutral-400 leading-relaxed">Strategic guidance on entering and growing in the federal market. From capture to execution, we help you win and deliver.</p>
+                        <p class="text-white leading-relaxed">Strategic guidance on entering and growing in the federal market. From capture to execution, we help you win and deliver.</p>
                     </div>
                 </div>
 
@@ -86,7 +86,7 @@
                 <div class="text-center reveal">
                     <div class="inline-block p-8 bg-fi-gray/30 border border-white/5 rounded-2xl backdrop-blur-sm">
                         <h2 class="text-2xl font-semibold text-white mb-4">Need Expert Guidance?</h2>
-                        <p class="text-neutral-400 mb-6 max-w-lg">Schedule a consultation to discuss how our advisory services can help you navigate technical and strategic challenges.</p>
+                        <p class="text-white mb-6 max-w-lg">Schedule a consultation to discuss how our advisory services can help you navigate technical and strategic challenges.</p>
                         <a href="/contact.html" class="btn-glass group inline-flex items-center space-x-2 text-white font-semibold px-8 py-4 rounded-xl transition-all duration-300">
                             <span>Schedule a Consultation</span>
                             <svg class="w-5 h-5 group-hover:translate-x-1 transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/partners.html
+++ b/partners.html
@@ -191,15 +191,15 @@
                         <div class="dropdown-menu">
                             <a href="/services/software-engineering.html" class="dropdown-item">
                                 <div class="font-medium text-white mb-1">Software Engineering</div>
-                                <div class="text-sm text-neutral-500">Custom software solutions for federal needs</div>
+                                <div class="text-sm text-white">Custom software solutions for federal needs</div>
                             </a>
                             <a href="/services/ai-systems.html" class="dropdown-item">
                                 <div class="font-medium text-white mb-1">AI Systems & Enablement</div>
-                                <div class="text-sm text-neutral-500">AI strategy, implementation & optimization</div>
+                                <div class="text-sm text-white">AI strategy, implementation & optimization</div>
                             </a>
                             <a href="/services/technical-advisory.html" class="dropdown-item">
                                 <div class="font-medium text-white mb-1">Technical Advisory</div>
-                                <div class="text-sm text-neutral-500">Software, AI & GovCon guidance</div>
+                                <div class="text-sm text-white">Software, AI & GovCon guidance</div>
                             </a>
                         </div>
                     </div>
@@ -241,7 +241,7 @@
                         <svg class="w-5 h-5 text-dynamic-accent" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z"/>
                         </svg>
-                        <span class="text-sm text-neutral-400 font-medium tracking-wide uppercase">Ecosystem</span>
+                        <span class="text-sm text-white font-medium tracking-wide uppercase">Ecosystem</span>
                     </div>
                     <h1 class="text-4xl md:text-6xl lg:text-7xl font-bold tracking-tight mb-6 reveal reveal-delay-1">
                         <span class="gradient-text">Our</span>
@@ -249,9 +249,9 @@
                         <span class="text-white">Partners</span>
                     </h1>
                     <div class="w-24 h-1 glow-line shimmer-line mx-auto mb-8 rounded-full reveal reveal-delay-2"></div>
-                    <p class="text-lg md:text-xl text-neutral-400 max-w-3xl mx-auto leading-relaxed reveal reveal-delay-2">
+                    <p class="text-lg md:text-xl text-white max-w-3xl mx-auto leading-relaxed reveal reveal-delay-2">
                         Strategic partnerships that amplify our capabilities and expand our reach.
-                        <span class="text-neutral-300">Together, we deliver exceptional value to the federal market.</span>
+                        <span class="text-white">Together, we deliver exceptional value to the federal market.</span>
                     </p>
                 </div>
 
@@ -266,7 +266,7 @@
                                 </svg>
                             </div>
                             <h3 class="text-xl font-semibold text-white mb-3">AWS</h3>
-                            <p class="text-neutral-400 text-sm">AWS Partner Network member with expertise in GovCloud deployments and FedRAMP-compliant architectures.</p>
+                            <p class="text-white text-sm">AWS Partner Network member with expertise in GovCloud deployments and FedRAMP-compliant architectures.</p>
                         </div>
 
                         <div class="parallax-card reveal reveal-delay-2 group p-8 bg-fi-gray/30 border border-white/5 rounded-2xl backdrop-blur-sm hover:border-dynamic-accent-30 transition-all duration-300 text-center" data-tilt>
@@ -276,7 +276,7 @@
                                 </svg>
                             </div>
                             <h3 class="text-xl font-semibold text-white mb-3">Microsoft Azure</h3>
-                            <p class="text-neutral-400 text-sm">Microsoft Partner with deep experience in Azure Government and hybrid cloud solutions for federal agencies.</p>
+                            <p class="text-white text-sm">Microsoft Partner with deep experience in Azure Government and hybrid cloud solutions for federal agencies.</p>
                         </div>
 
                         <div class="parallax-card reveal reveal-delay-3 group p-8 bg-fi-gray/30 border border-white/5 rounded-2xl backdrop-blur-sm hover:border-dynamic-accent-30 transition-all duration-300 text-center" data-tilt>
@@ -286,7 +286,7 @@
                                 </svg>
                             </div>
                             <h3 class="text-xl font-semibold text-white mb-3">Snowflake</h3>
-                            <p class="text-neutral-400 text-sm">Snowflake partner delivering scalable data warehouse solutions for federal data analytics needs.</p>
+                            <p class="text-white text-sm">Snowflake partner delivering scalable data warehouse solutions for federal data analytics needs.</p>
                         </div>
                     </div>
                 </div>
@@ -303,25 +303,25 @@
                                         <svg class="w-5 h-5 text-dynamic-accent flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
                                         </svg>
-                                        <span class="text-neutral-400">Deep technical expertise in software development and AI</span>
+                                        <span class="text-white">Deep technical expertise in software development and AI</span>
                                     </li>
                                     <li class="flex items-start gap-3">
                                         <svg class="w-5 h-5 text-dynamic-accent flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
                                         </svg>
-                                        <span class="text-neutral-400">Proven past performance with federal agencies</span>
+                                        <span class="text-white">Proven past performance with federal agencies</span>
                                     </li>
                                     <li class="flex items-start gap-3">
                                         <svg class="w-5 h-5 text-dynamic-accent flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
                                         </svg>
-                                        <span class="text-neutral-400">Flexible engagement models for prime/sub arrangements</span>
+                                        <span class="text-white">Flexible engagement models for prime/sub arrangements</span>
                                     </li>
                                     <li class="flex items-start gap-3">
                                         <svg class="w-5 h-5 text-dynamic-accent flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
                                         </svg>
-                                        <span class="text-neutral-400">Commitment to long-term partnership success</span>
+                                        <span class="text-white">Commitment to long-term partnership success</span>
                                     </li>
                                 </ul>
                             </div>
@@ -332,25 +332,25 @@
                                         <svg class="w-5 h-5 text-dynamic-accent flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
                                         </svg>
-                                        <span class="text-neutral-400">Prime contractors seeking technical expertise</span>
+                                        <span class="text-white">Prime contractors seeking technical expertise</span>
                                     </li>
                                     <li class="flex items-start gap-3">
                                         <svg class="w-5 h-5 text-dynamic-accent flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
                                         </svg>
-                                        <span class="text-neutral-400">Small businesses with complementary capabilities</span>
+                                        <span class="text-white">Small businesses with complementary capabilities</span>
                                     </li>
                                     <li class="flex items-start gap-3">
                                         <svg class="w-5 h-5 text-dynamic-accent flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
                                         </svg>
-                                        <span class="text-neutral-400">Technology vendors expanding into federal</span>
+                                        <span class="text-white">Technology vendors expanding into federal</span>
                                     </li>
                                     <li class="flex items-start gap-3">
                                         <svg class="w-5 h-5 text-dynamic-accent flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
                                         </svg>
-                                        <span class="text-neutral-400">Organizations pursuing specific contract vehicles</span>
+                                        <span class="text-white">Organizations pursuing specific contract vehicles</span>
                                     </li>
                                 </ul>
                             </div>
@@ -362,7 +362,7 @@
                 <div class="text-center reveal">
                     <div class="inline-block p-8 bg-fi-gray/30 border border-white/5 rounded-2xl backdrop-blur-sm">
                         <h2 class="text-2xl font-semibold text-white mb-4">Interested in Partnering?</h2>
-                        <p class="text-neutral-400 mb-6 max-w-lg">We're always looking for strategic partners who share our commitment to excellence. Let's explore how we can work together.</p>
+                        <p class="text-white mb-6 max-w-lg">We're always looking for strategic partners who share our commitment to excellence. Let's explore how we can work together.</p>
                         <a href="/contact.html" class="btn-glass group inline-flex items-center space-x-2 text-white font-semibold px-8 py-4 rounded-xl transition-all duration-300">
                             <span>Discuss Partnership</span>
                             <svg class="w-5 h-5 group-hover:translate-x-1 transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -376,10 +376,10 @@
 
         <footer class="py-8 px-6 md:px-12 lg:px-20 border-t border-white/5">
             <div class="flex flex-col md:flex-row items-center justify-between gap-4">
-                <p class="text-neutral-600 text-sm">&copy; 2026 Federal Innovations. All rights reserved.</p>
-                <div class="flex items-center space-x-1 text-neutral-600 text-sm">
+                <p class="text-white text-sm">&copy; 2026 Federal Innovations. All rights reserved.</p>
+                <div class="flex items-center space-x-1 text-white text-sm">
                     <span>Washington, D.C.</span>
-                    <span class="text-neutral-700">|</span>
+                    <span class="text-white">|</span>
                     <span>Empowering government contractors</span>
                 </div>
             </div>

--- a/past-performance.html
+++ b/past-performance.html
@@ -191,15 +191,15 @@
                         <div class="dropdown-menu">
                             <a href="/services/software-engineering.html" class="dropdown-item">
                                 <div class="font-medium text-white mb-1">Software Engineering</div>
-                                <div class="text-sm text-neutral-500">Custom software solutions for federal needs</div>
+                                <div class="text-sm text-white">Custom software solutions for federal needs</div>
                             </a>
                             <a href="/services/ai-systems.html" class="dropdown-item">
                                 <div class="font-medium text-white mb-1">AI Systems & Enablement</div>
-                                <div class="text-sm text-neutral-500">AI strategy, implementation & optimization</div>
+                                <div class="text-sm text-white">AI strategy, implementation & optimization</div>
                             </a>
                             <a href="/services/technical-advisory.html" class="dropdown-item">
                                 <div class="font-medium text-white mb-1">Technical Advisory</div>
-                                <div class="text-sm text-neutral-500">Software, AI & GovCon guidance</div>
+                                <div class="text-sm text-white">Software, AI & GovCon guidance</div>
                             </a>
                         </div>
                     </div>
@@ -241,7 +241,7 @@
                         <svg class="w-5 h-5 text-dynamic-accent" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M9 12l2 2 4-4M7.835 4.697a3.42 3.42 0 001.946-.806 3.42 3.42 0 014.438 0 3.42 3.42 0 001.946.806 3.42 3.42 0 013.138 3.138 3.42 3.42 0 00.806 1.946 3.42 3.42 0 010 4.438 3.42 3.42 0 00-.806 1.946 3.42 3.42 0 01-3.138 3.138 3.42 3.42 0 00-1.946.806 3.42 3.42 0 01-4.438 0 3.42 3.42 0 00-1.946-.806 3.42 3.42 0 01-3.138-3.138 3.42 3.42 0 00-.806-1.946 3.42 3.42 0 010-4.438 3.42 3.42 0 00.806-1.946 3.42 3.42 0 013.138-3.138z"/>
                         </svg>
-                        <span class="text-sm text-neutral-400 font-medium tracking-wide uppercase">Track Record</span>
+                        <span class="text-sm text-white font-medium tracking-wide uppercase">Track Record</span>
                     </div>
                     <h1 class="text-4xl md:text-6xl lg:text-7xl font-bold tracking-tight mb-6 reveal reveal-delay-1">
                         <span class="gradient-text">Past</span>
@@ -249,9 +249,9 @@
                         <span class="text-white">Performance</span>
                     </h1>
                     <div class="w-24 h-1 glow-line shimmer-line mx-auto mb-8 rounded-full reveal reveal-delay-2"></div>
-                    <p class="text-lg md:text-xl text-neutral-400 max-w-3xl mx-auto leading-relaxed reveal reveal-delay-2">
+                    <p class="text-lg md:text-xl text-white max-w-3xl mx-auto leading-relaxed reveal reveal-delay-2">
                         A proven track record of delivering mission-critical solutions for federal agencies and government contractors.
-                        <span class="text-neutral-300">Results that speak for themselves.</span>
+                        <span class="text-white">Results that speak for themselves.</span>
                     </p>
                 </div>
 
@@ -259,19 +259,19 @@
                 <div class="grid grid-cols-2 md:grid-cols-4 gap-6 mb-16 reveal">
                     <div class="text-center p-6 bg-fi-gray/30 border border-white/5 rounded-2xl backdrop-blur-sm">
                         <div class="text-3xl md:text-4xl font-bold text-dynamic-accent mb-2">15+</div>
-                        <div class="text-neutral-400 text-sm">Federal Projects</div>
+                        <div class="text-white text-sm">Federal Projects</div>
                     </div>
                     <div class="text-center p-6 bg-fi-gray/30 border border-white/5 rounded-2xl backdrop-blur-sm">
                         <div class="text-3xl md:text-4xl font-bold text-dynamic-accent mb-2">100%</div>
-                        <div class="text-neutral-400 text-sm">On-Time Delivery</div>
+                        <div class="text-white text-sm">On-Time Delivery</div>
                     </div>
                     <div class="text-center p-6 bg-fi-gray/30 border border-white/5 rounded-2xl backdrop-blur-sm">
                         <div class="text-3xl md:text-4xl font-bold text-dynamic-accent mb-2">8+</div>
-                        <div class="text-neutral-400 text-sm">Agency Partners</div>
+                        <div class="text-white text-sm">Agency Partners</div>
                     </div>
                     <div class="text-center p-6 bg-fi-gray/30 border border-white/5 rounded-2xl backdrop-blur-sm">
                         <div class="text-3xl md:text-4xl font-bold text-dynamic-accent mb-2">5</div>
-                        <div class="text-neutral-400 text-sm">Years Experience</div>
+                        <div class="text-white text-sm">Years Experience</div>
                     </div>
                 </div>
 
@@ -291,11 +291,11 @@
                                     <h3 class="text-xl font-semibold text-white">Enterprise Security Platform Modernization</h3>
                                     <span class="px-3 py-1 bg-dynamic-accent-10 rounded-full text-xs text-dynamic-accent font-medium">Defense</span>
                                 </div>
-                                <p class="text-neutral-400 mb-4">Led the modernization of a legacy security monitoring platform serving 50,000+ users. Migrated to cloud-native architecture on AWS GovCloud while maintaining FedRAMP High authorization.</p>
+                                <p class="text-white mb-4">Led the modernization of a legacy security monitoring platform serving 50,000+ users. Migrated to cloud-native architecture on AWS GovCloud while maintaining FedRAMP High authorization.</p>
                                 <div class="flex flex-wrap gap-2">
-                                    <span class="px-3 py-1 bg-fi-dark rounded-lg text-xs text-neutral-400">AWS GovCloud</span>
-                                    <span class="px-3 py-1 bg-fi-dark rounded-lg text-xs text-neutral-400">Kubernetes</span>
-                                    <span class="px-3 py-1 bg-fi-dark rounded-lg text-xs text-neutral-400">FedRAMP High</span>
+                                    <span class="px-3 py-1 bg-fi-dark rounded-lg text-xs text-white">AWS GovCloud</span>
+                                    <span class="px-3 py-1 bg-fi-dark rounded-lg text-xs text-white">Kubernetes</span>
+                                    <span class="px-3 py-1 bg-fi-dark rounded-lg text-xs text-white">FedRAMP High</span>
                                 </div>
                             </div>
                         </div>
@@ -313,11 +313,11 @@
                                     <h3 class="text-xl font-semibold text-white">AI-Powered Document Processing System</h3>
                                     <span class="px-3 py-1 bg-dynamic-accent-10 rounded-full text-xs text-dynamic-accent font-medium">Civilian</span>
                                 </div>
-                                <p class="text-neutral-400 mb-4">Designed and implemented an AI system to automate document classification and data extraction, reducing manual processing time by 85% and improving accuracy to 99.2%.</p>
+                                <p class="text-white mb-4">Designed and implemented an AI system to automate document classification and data extraction, reducing manual processing time by 85% and improving accuracy to 99.2%.</p>
                                 <div class="flex flex-wrap gap-2">
-                                    <span class="px-3 py-1 bg-fi-dark rounded-lg text-xs text-neutral-400">Machine Learning</span>
-                                    <span class="px-3 py-1 bg-fi-dark rounded-lg text-xs text-neutral-400">NLP</span>
-                                    <span class="px-3 py-1 bg-fi-dark rounded-lg text-xs text-neutral-400">Python</span>
+                                    <span class="px-3 py-1 bg-fi-dark rounded-lg text-xs text-white">Machine Learning</span>
+                                    <span class="px-3 py-1 bg-fi-dark rounded-lg text-xs text-white">NLP</span>
+                                    <span class="px-3 py-1 bg-fi-dark rounded-lg text-xs text-white">Python</span>
                                 </div>
                             </div>
                         </div>
@@ -335,11 +335,11 @@
                                     <h3 class="text-xl font-semibold text-white">Data Analytics Platform for Health Agency</h3>
                                     <span class="px-3 py-1 bg-dynamic-accent-10 rounded-full text-xs text-dynamic-accent font-medium">Health</span>
                                 </div>
-                                <p class="text-neutral-400 mb-4">Built a comprehensive data analytics platform enabling real-time insights across multiple data sources, supporting evidence-based policy decisions affecting millions of citizens.</p>
+                                <p class="text-white mb-4">Built a comprehensive data analytics platform enabling real-time insights across multiple data sources, supporting evidence-based policy decisions affecting millions of citizens.</p>
                                 <div class="flex flex-wrap gap-2">
-                                    <span class="px-3 py-1 bg-fi-dark rounded-lg text-xs text-neutral-400">Data Engineering</span>
-                                    <span class="px-3 py-1 bg-fi-dark rounded-lg text-xs text-neutral-400">Snowflake</span>
-                                    <span class="px-3 py-1 bg-fi-dark rounded-lg text-xs text-neutral-400">Tableau</span>
+                                    <span class="px-3 py-1 bg-fi-dark rounded-lg text-xs text-white">Data Engineering</span>
+                                    <span class="px-3 py-1 bg-fi-dark rounded-lg text-xs text-white">Snowflake</span>
+                                    <span class="px-3 py-1 bg-fi-dark rounded-lg text-xs text-white">Tableau</span>
                                 </div>
                             </div>
                         </div>
@@ -350,7 +350,7 @@
                 <div class="text-center reveal">
                     <div class="inline-block p-8 bg-fi-gray/30 border border-white/5 rounded-2xl backdrop-blur-sm">
                         <h2 class="text-2xl font-semibold text-white mb-4">Ready to Add Your Success Story?</h2>
-                        <p class="text-neutral-400 mb-6 max-w-lg">Let's discuss how we can bring the same level of excellence to your next federal project.</p>
+                        <p class="text-white mb-6 max-w-lg">Let's discuss how we can bring the same level of excellence to your next federal project.</p>
                         <a href="/contact.html" class="btn-glass group inline-flex items-center space-x-2 text-white font-semibold px-8 py-4 rounded-xl transition-all duration-300">
                             <span>Start a Project</span>
                             <svg class="w-5 h-5 group-hover:translate-x-1 transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -364,10 +364,10 @@
 
         <footer class="py-8 px-6 md:px-12 lg:px-20 border-t border-white/5">
             <div class="flex flex-col md:flex-row items-center justify-between gap-4">
-                <p class="text-neutral-600 text-sm">&copy; 2026 Federal Innovations. All rights reserved.</p>
-                <div class="flex items-center space-x-1 text-neutral-600 text-sm">
+                <p class="text-white text-sm">&copy; 2026 Federal Innovations. All rights reserved.</p>
+                <div class="flex items-center space-x-1 text-white text-sm">
                     <span>Washington, D.C.</span>
-                    <span class="text-neutral-700">|</span>
+                    <span class="text-white">|</span>
                     <span>Empowering government contractors</span>
                 </div>
             </div>

--- a/services/ai-systems.html
+++ b/services/ai-systems.html
@@ -195,15 +195,15 @@
                         <div class="dropdown-menu">
                             <a href="/services/software-engineering.html" class="dropdown-item">
                                 <div class="font-medium text-white mb-1">Software Engineering</div>
-                                <div class="text-sm text-neutral-500">Custom software solutions for federal needs</div>
+                                <div class="text-sm text-white">Custom software solutions for federal needs</div>
                             </a>
                             <a href="/services/ai-systems.html" class="dropdown-item active">
                                 <div class="font-medium text-white mb-1">AI Systems & Enablement</div>
-                                <div class="text-sm text-neutral-500">AI strategy, implementation & optimization</div>
+                                <div class="text-sm text-white">AI strategy, implementation & optimization</div>
                             </a>
                             <a href="/services/technical-advisory.html" class="dropdown-item">
                                 <div class="font-medium text-white mb-1">Technical Advisory</div>
-                                <div class="text-sm text-neutral-500">Software, AI & GovCon guidance</div>
+                                <div class="text-sm text-white">Software, AI & GovCon guidance</div>
                             </a>
                         </div>
                     </div>
@@ -245,7 +245,7 @@
                         <svg class="w-5 h-5 text-dynamic-accent" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/>
                         </svg>
-                        <span class="text-sm text-neutral-400 font-medium tracking-wide uppercase">Services</span>
+                        <span class="text-sm text-white font-medium tracking-wide uppercase">Services</span>
                     </div>
                     <h1 class="text-4xl md:text-6xl lg:text-7xl font-bold tracking-tight mb-6 reveal reveal-delay-1">
                         <span class="gradient-text">AI Systems</span>
@@ -253,9 +253,9 @@
                         <span class="text-white">& Enablement</span>
                     </h1>
                     <div class="w-24 h-1 glow-line shimmer-line mx-auto mb-8 rounded-full reveal reveal-delay-2"></div>
-                    <p class="text-lg md:text-xl text-neutral-400 max-w-3xl mx-auto leading-relaxed reveal reveal-delay-2">
+                    <p class="text-lg md:text-xl text-white max-w-3xl mx-auto leading-relaxed reveal reveal-delay-2">
                         Strategic AI implementation and optimization for federal agencies.
-                        <span class="text-neutral-300">From strategy to deployment, we help you harness the power of artificial intelligence responsibly.</span>
+                        <span class="text-white">From strategy to deployment, we help you harness the power of artificial intelligence responsibly.</span>
                     </p>
                 </div>
 
@@ -268,7 +268,7 @@
                             </svg>
                         </div>
                         <h3 class="text-xl font-semibold text-white mb-3">AI Strategy & Roadmap</h3>
-                        <p class="text-neutral-400 leading-relaxed">Develop comprehensive AI adoption strategies aligned with your mission. We identify high-impact use cases and create actionable implementation roadmaps.</p>
+                        <p class="text-white leading-relaxed">Develop comprehensive AI adoption strategies aligned with your mission. We identify high-impact use cases and create actionable implementation roadmaps.</p>
                     </div>
 
                     <div class="parallax-card reveal reveal-delay-2 group p-8 bg-fi-gray/30 border border-white/5 rounded-2xl backdrop-blur-sm hover:border-dynamic-accent-30 transition-all duration-300" data-tilt>
@@ -278,7 +278,7 @@
                             </svg>
                         </div>
                         <h3 class="text-xl font-semibold text-white mb-3">ML/AI Development</h3>
-                        <p class="text-neutral-400 leading-relaxed">Custom machine learning models and AI solutions built for your specific needs. From NLP to computer vision, we develop and deploy production-ready systems.</p>
+                        <p class="text-white leading-relaxed">Custom machine learning models and AI solutions built for your specific needs. From NLP to computer vision, we develop and deploy production-ready systems.</p>
                     </div>
 
                     <div class="parallax-card reveal reveal-delay-3 group p-8 bg-fi-gray/30 border border-white/5 rounded-2xl backdrop-blur-sm hover:border-dynamic-accent-30 transition-all duration-300" data-tilt>
@@ -288,7 +288,7 @@
                             </svg>
                         </div>
                         <h3 class="text-xl font-semibold text-white mb-3">LLM Integration</h3>
-                        <p class="text-neutral-400 leading-relaxed">Integrate large language models into your workflows responsibly. We help you leverage GPT, Claude, and other LLMs while maintaining security and compliance.</p>
+                        <p class="text-white leading-relaxed">Integrate large language models into your workflows responsibly. We help you leverage GPT, Claude, and other LLMs while maintaining security and compliance.</p>
                     </div>
 
                     <div class="parallax-card reveal reveal-delay-4 group p-8 bg-fi-gray/30 border border-white/5 rounded-2xl backdrop-blur-sm hover:border-dynamic-accent-30 transition-all duration-300" data-tilt>
@@ -298,7 +298,7 @@
                             </svg>
                         </div>
                         <h3 class="text-xl font-semibold text-white mb-3">Responsible AI</h3>
-                        <p class="text-neutral-400 leading-relaxed">Implement AI governance frameworks, bias detection, and explainability. We ensure your AI systems are ethical, transparent, and aligned with federal guidelines.</p>
+                        <p class="text-white leading-relaxed">Implement AI governance frameworks, bias detection, and explainability. We ensure your AI systems are ethical, transparent, and aligned with federal guidelines.</p>
                     </div>
                 </div>
 
@@ -311,28 +311,28 @@
                                 <span class="text-dynamic-accent font-bold text-lg">1</span>
                             </div>
                             <h4 class="text-white font-medium mb-2">Assess</h4>
-                            <p class="text-neutral-500 text-sm">Evaluate current capabilities and identify AI opportunities</p>
+                            <p class="text-white text-sm">Evaluate current capabilities and identify AI opportunities</p>
                         </div>
                         <div class="text-center p-6">
                             <div class="w-12 h-12 bg-dynamic-accent-10 rounded-full flex items-center justify-center mx-auto mb-4">
                                 <span class="text-dynamic-accent font-bold text-lg">2</span>
                             </div>
                             <h4 class="text-white font-medium mb-2">Design</h4>
-                            <p class="text-neutral-500 text-sm">Architect solutions that fit your infrastructure and requirements</p>
+                            <p class="text-white text-sm">Architect solutions that fit your infrastructure and requirements</p>
                         </div>
                         <div class="text-center p-6">
                             <div class="w-12 h-12 bg-dynamic-accent-10 rounded-full flex items-center justify-center mx-auto mb-4">
                                 <span class="text-dynamic-accent font-bold text-lg">3</span>
                             </div>
                             <h4 class="text-white font-medium mb-2">Implement</h4>
-                            <p class="text-neutral-500 text-sm">Build, test, and deploy AI solutions with continuous validation</p>
+                            <p class="text-white text-sm">Build, test, and deploy AI solutions with continuous validation</p>
                         </div>
                         <div class="text-center p-6">
                             <div class="w-12 h-12 bg-dynamic-accent-10 rounded-full flex items-center justify-center mx-auto mb-4">
                                 <span class="text-dynamic-accent font-bold text-lg">4</span>
                             </div>
                             <h4 class="text-white font-medium mb-2">Optimize</h4>
-                            <p class="text-neutral-500 text-sm">Monitor performance and continuously improve model accuracy</p>
+                            <p class="text-white text-sm">Monitor performance and continuously improve model accuracy</p>
                         </div>
                     </div>
                 </div>
@@ -341,7 +341,7 @@
                 <div class="text-center reveal">
                     <div class="inline-block p-8 bg-fi-gray/30 border border-white/5 rounded-2xl backdrop-blur-sm">
                         <h2 class="text-2xl font-semibold text-white mb-4">Ready to Transform with AI?</h2>
-                        <p class="text-neutral-400 mb-6 max-w-lg">Let's explore how AI can enhance your agency's capabilities while maintaining security and compliance.</p>
+                        <p class="text-white mb-6 max-w-lg">Let's explore how AI can enhance your agency's capabilities while maintaining security and compliance.</p>
                         <a href="/contact.html" class="btn-glass group inline-flex items-center space-x-2 text-white font-semibold px-8 py-4 rounded-xl transition-all duration-300">
                             <span>Start the Conversation</span>
                             <svg class="w-5 h-5 group-hover:translate-x-1 transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -355,10 +355,10 @@
 
         <footer class="py-8 px-6 md:px-12 lg:px-20 border-t border-white/5">
             <div class="flex flex-col md:flex-row items-center justify-between gap-4">
-                <p class="text-neutral-600 text-sm">&copy; 2026 Federal Innovations. All rights reserved.</p>
-                <div class="flex items-center space-x-1 text-neutral-600 text-sm">
+                <p class="text-white text-sm">&copy; 2026 Federal Innovations. All rights reserved.</p>
+                <div class="flex items-center space-x-1 text-white text-sm">
                     <span>Washington, D.C.</span>
-                    <span class="text-neutral-700">|</span>
+                    <span class="text-white">|</span>
                     <span>Empowering government contractors</span>
                 </div>
             </div>

--- a/services/software-engineering.html
+++ b/services/software-engineering.html
@@ -246,15 +246,15 @@
                         <div class="dropdown-menu">
                             <a href="/services/software-engineering.html" class="dropdown-item active">
                                 <div class="font-medium text-white mb-1">Software Engineering</div>
-                                <div class="text-sm text-neutral-500">Custom software solutions for federal needs</div>
+                                <div class="text-sm text-white">Custom software solutions for federal needs</div>
                             </a>
                             <a href="/services/ai-systems.html" class="dropdown-item">
                                 <div class="font-medium text-white mb-1">AI Systems & Enablement</div>
-                                <div class="text-sm text-neutral-500">AI strategy, implementation & optimization</div>
+                                <div class="text-sm text-white">AI strategy, implementation & optimization</div>
                             </a>
                             <a href="/services/technical-advisory.html" class="dropdown-item">
                                 <div class="font-medium text-white mb-1">Technical Advisory</div>
-                                <div class="text-sm text-neutral-500">Software, AI & GovCon guidance</div>
+                                <div class="text-sm text-white">Software, AI & GovCon guidance</div>
                             </a>
                         </div>
                     </div>
@@ -296,7 +296,7 @@
                         <svg class="w-5 h-5 text-dynamic-accent" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4"/>
                         </svg>
-                        <span class="text-sm text-neutral-400 font-medium tracking-wide uppercase">Services</span>
+                        <span class="text-sm text-white font-medium tracking-wide uppercase">Services</span>
                     </div>
                     <h1 class="text-4xl md:text-6xl lg:text-7xl font-bold tracking-tight mb-6 reveal reveal-delay-1">
                         <span class="gradient-text">Software</span>
@@ -304,9 +304,9 @@
                         <span class="text-white">Engineering</span>
                     </h1>
                     <div class="w-24 h-1 glow-line shimmer-line mx-auto mb-8 rounded-full reveal reveal-delay-2"></div>
-                    <p class="text-lg md:text-xl text-neutral-400 max-w-3xl mx-auto leading-relaxed reveal reveal-delay-2">
+                    <p class="text-lg md:text-xl text-white max-w-3xl mx-auto leading-relaxed reveal reveal-delay-2">
                         Custom software solutions designed for the unique requirements of federal agencies and government contractors.
-                        <span class="text-neutral-300">Built secure, compliant, and scalable from day one.</span>
+                        <span class="text-white">Built secure, compliant, and scalable from day one.</span>
                     </p>
                 </div>
 
@@ -319,7 +319,7 @@
                             </svg>
                         </div>
                         <h3 class="text-xl font-semibold text-white mb-3">Full-Stack Development</h3>
-                        <p class="text-neutral-400 leading-relaxed">End-to-end application development using modern frameworks and cloud-native architectures. From React frontends to microservices backends, we build systems that scale.</p>
+                        <p class="text-white leading-relaxed">End-to-end application development using modern frameworks and cloud-native architectures. From React frontends to microservices backends, we build systems that scale.</p>
                     </div>
 
                     <div class="parallax-card reveal reveal-delay-2 group p-8 bg-fi-gray/30 border border-white/5 rounded-2xl backdrop-blur-sm hover:border-dynamic-accent-30 transition-all duration-300" data-tilt>
@@ -329,7 +329,7 @@
                             </svg>
                         </div>
                         <h3 class="text-xl font-semibold text-white mb-3">Secure Development</h3>
-                        <p class="text-neutral-400 leading-relaxed">Security-first development practices aligned with NIST, FedRAMP, and FISMA requirements. Every line of code is written with compliance in mind.</p>
+                        <p class="text-white leading-relaxed">Security-first development practices aligned with NIST, FedRAMP, and FISMA requirements. Every line of code is written with compliance in mind.</p>
                     </div>
 
                     <div class="parallax-card reveal reveal-delay-3 group p-8 bg-fi-gray/30 border border-white/5 rounded-2xl backdrop-blur-sm hover:border-dynamic-accent-30 transition-all duration-300" data-tilt>
@@ -339,7 +339,7 @@
                             </svg>
                         </div>
                         <h3 class="text-xl font-semibold text-white mb-3">Cloud Migration</h3>
-                        <p class="text-neutral-400 leading-relaxed">Seamless migration to AWS GovCloud, Azure Government, or hybrid environments. We modernize legacy systems while ensuring zero downtime.</p>
+                        <p class="text-white leading-relaxed">Seamless migration to AWS GovCloud, Azure Government, or hybrid environments. We modernize legacy systems while ensuring zero downtime.</p>
                     </div>
 
                     <div class="parallax-card reveal reveal-delay-4 group p-8 bg-fi-gray/30 border border-white/5 rounded-2xl backdrop-blur-sm hover:border-dynamic-accent-30 transition-all duration-300" data-tilt>
@@ -349,7 +349,7 @@
                             </svg>
                         </div>
                         <h3 class="text-xl font-semibold text-white mb-3">Data Engineering</h3>
-                        <p class="text-neutral-400 leading-relaxed">Build robust data pipelines, warehouses, and analytics platforms. Transform raw data into actionable insights for better decision-making.</p>
+                        <p class="text-white leading-relaxed">Build robust data pipelines, warehouses, and analytics platforms. Transform raw data into actionable insights for better decision-making.</p>
                     </div>
                 </div>
 
@@ -357,18 +357,18 @@
                 <div class="reveal mb-16">
                     <h2 class="text-2xl font-semibold text-white mb-8 text-center">Technologies We Work With</h2>
                     <div class="flex flex-wrap justify-center gap-4">
-                        <span class="px-4 py-2 bg-fi-gray/50 border border-white/10 rounded-lg text-neutral-300 text-sm">Python</span>
-                        <span class="px-4 py-2 bg-fi-gray/50 border border-white/10 rounded-lg text-neutral-300 text-sm">Java</span>
-                        <span class="px-4 py-2 bg-fi-gray/50 border border-white/10 rounded-lg text-neutral-300 text-sm">TypeScript</span>
-                        <span class="px-4 py-2 bg-fi-gray/50 border border-white/10 rounded-lg text-neutral-300 text-sm">React</span>
-                        <span class="px-4 py-2 bg-fi-gray/50 border border-white/10 rounded-lg text-neutral-300 text-sm">Node.js</span>
-                        <span class="px-4 py-2 bg-fi-gray/50 border border-white/10 rounded-lg text-neutral-300 text-sm">AWS GovCloud</span>
-                        <span class="px-4 py-2 bg-fi-gray/50 border border-white/10 rounded-lg text-neutral-300 text-sm">Azure Government</span>
-                        <span class="px-4 py-2 bg-fi-gray/50 border border-white/10 rounded-lg text-neutral-300 text-sm">Kubernetes</span>
-                        <span class="px-4 py-2 bg-fi-gray/50 border border-white/10 rounded-lg text-neutral-300 text-sm">Docker</span>
-                        <span class="px-4 py-2 bg-fi-gray/50 border border-white/10 rounded-lg text-neutral-300 text-sm">PostgreSQL</span>
-                        <span class="px-4 py-2 bg-fi-gray/50 border border-white/10 rounded-lg text-neutral-300 text-sm">MongoDB</span>
-                        <span class="px-4 py-2 bg-fi-gray/50 border border-white/10 rounded-lg text-neutral-300 text-sm">Terraform</span>
+                        <span class="px-4 py-2 bg-fi-gray/50 border border-white/10 rounded-lg text-white text-sm">Python</span>
+                        <span class="px-4 py-2 bg-fi-gray/50 border border-white/10 rounded-lg text-white text-sm">Java</span>
+                        <span class="px-4 py-2 bg-fi-gray/50 border border-white/10 rounded-lg text-white text-sm">TypeScript</span>
+                        <span class="px-4 py-2 bg-fi-gray/50 border border-white/10 rounded-lg text-white text-sm">React</span>
+                        <span class="px-4 py-2 bg-fi-gray/50 border border-white/10 rounded-lg text-white text-sm">Node.js</span>
+                        <span class="px-4 py-2 bg-fi-gray/50 border border-white/10 rounded-lg text-white text-sm">AWS GovCloud</span>
+                        <span class="px-4 py-2 bg-fi-gray/50 border border-white/10 rounded-lg text-white text-sm">Azure Government</span>
+                        <span class="px-4 py-2 bg-fi-gray/50 border border-white/10 rounded-lg text-white text-sm">Kubernetes</span>
+                        <span class="px-4 py-2 bg-fi-gray/50 border border-white/10 rounded-lg text-white text-sm">Docker</span>
+                        <span class="px-4 py-2 bg-fi-gray/50 border border-white/10 rounded-lg text-white text-sm">PostgreSQL</span>
+                        <span class="px-4 py-2 bg-fi-gray/50 border border-white/10 rounded-lg text-white text-sm">MongoDB</span>
+                        <span class="px-4 py-2 bg-fi-gray/50 border border-white/10 rounded-lg text-white text-sm">Terraform</span>
                     </div>
                 </div>
 
@@ -376,7 +376,7 @@
                 <div class="text-center reveal">
                     <div class="inline-block p-8 bg-fi-gray/30 border border-white/5 rounded-2xl backdrop-blur-sm">
                         <h2 class="text-2xl font-semibold text-white mb-4">Ready to Build Something Great?</h2>
-                        <p class="text-neutral-400 mb-6 max-w-lg">Let's discuss how our software engineering expertise can help your agency or organization achieve its mission.</p>
+                        <p class="text-white mb-6 max-w-lg">Let's discuss how our software engineering expertise can help your agency or organization achieve its mission.</p>
                         <a href="/contact.html" class="btn-glass group inline-flex items-center space-x-2 text-white font-semibold px-8 py-4 rounded-xl transition-all duration-300">
                             <span>Get in Touch</span>
                             <svg class="w-5 h-5 group-hover:translate-x-1 transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -390,10 +390,10 @@
 
         <footer class="py-8 px-6 md:px-12 lg:px-20 border-t border-white/5">
             <div class="flex flex-col md:flex-row items-center justify-between gap-4">
-                <p class="text-neutral-600 text-sm">&copy; 2026 Federal Innovations. All rights reserved.</p>
-                <div class="flex items-center space-x-1 text-neutral-600 text-sm">
+                <p class="text-white text-sm">&copy; 2026 Federal Innovations. All rights reserved.</p>
+                <div class="flex items-center space-x-1 text-white text-sm">
                     <span>Washington, D.C.</span>
-                    <span class="text-neutral-700">|</span>
+                    <span class="text-white">|</span>
                     <span>Empowering government contractors</span>
                 </div>
             </div>

--- a/services/technical-advisory.html
+++ b/services/technical-advisory.html
@@ -195,15 +195,15 @@
                         <div class="dropdown-menu">
                             <a href="/services/software-engineering.html" class="dropdown-item">
                                 <div class="font-medium text-white mb-1">Software Engineering</div>
-                                <div class="text-sm text-neutral-500">Custom software solutions for federal needs</div>
+                                <div class="text-sm text-white">Custom software solutions for federal needs</div>
                             </a>
                             <a href="/services/ai-systems.html" class="dropdown-item">
                                 <div class="font-medium text-white mb-1">AI Systems & Enablement</div>
-                                <div class="text-sm text-neutral-500">AI strategy, implementation & optimization</div>
+                                <div class="text-sm text-white">AI strategy, implementation & optimization</div>
                             </a>
                             <a href="/services/technical-advisory.html" class="dropdown-item active">
                                 <div class="font-medium text-white mb-1">Technical Advisory</div>
-                                <div class="text-sm text-neutral-500">Software, AI & GovCon guidance</div>
+                                <div class="text-sm text-white">Software, AI & GovCon guidance</div>
                             </a>
                         </div>
                     </div>
@@ -245,7 +245,7 @@
                         <svg class="w-5 h-5 text-dynamic-accent" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4"/>
                         </svg>
-                        <span class="text-sm text-neutral-400 font-medium tracking-wide uppercase">Services</span>
+                        <span class="text-sm text-white font-medium tracking-wide uppercase">Services</span>
                     </div>
                     <h1 class="text-4xl md:text-6xl lg:text-7xl font-bold tracking-tight mb-6 reveal reveal-delay-1">
                         <span class="gradient-text">Technical</span>
@@ -253,9 +253,9 @@
                         <span class="text-white">Advisory</span>
                     </h1>
                     <div class="w-24 h-1 glow-line shimmer-line mx-auto mb-8 rounded-full reveal reveal-delay-2"></div>
-                    <p class="text-lg md:text-xl text-neutral-400 max-w-3xl mx-auto leading-relaxed reveal reveal-delay-2">
+                    <p class="text-lg md:text-xl text-white max-w-3xl mx-auto leading-relaxed reveal reveal-delay-2">
                         Expert guidance on software architecture, AI strategy, and government contracting.
-                        <span class="text-neutral-300">Strategic advice from practitioners who understand both technology and the federal marketplace.</span>
+                        <span class="text-white">Strategic advice from practitioners who understand both technology and the federal marketplace.</span>
                     </p>
                 </div>
 
@@ -268,7 +268,7 @@
                             </svg>
                         </div>
                         <h3 class="text-xl font-semibold text-white mb-3">Architecture Review</h3>
-                        <p class="text-neutral-400 leading-relaxed">Expert assessment of your software architecture with actionable recommendations for improvement, scalability, and security.</p>
+                        <p class="text-white leading-relaxed">Expert assessment of your software architecture with actionable recommendations for improvement, scalability, and security.</p>
                     </div>
 
                     <div class="parallax-card reveal reveal-delay-2 group p-8 bg-fi-gray/30 border border-white/5 rounded-2xl backdrop-blur-sm hover:border-dynamic-accent-30 transition-all duration-300" data-tilt>
@@ -278,7 +278,7 @@
                             </svg>
                         </div>
                         <h3 class="text-xl font-semibold text-white mb-3">Proposal Support</h3>
-                        <p class="text-neutral-400 leading-relaxed">Technical writing and strategy support for federal proposals. We help craft winning technical volumes that resonate with evaluators.</p>
+                        <p class="text-white leading-relaxed">Technical writing and strategy support for federal proposals. We help craft winning technical volumes that resonate with evaluators.</p>
                     </div>
 
                     <div class="parallax-card reveal reveal-delay-3 group p-8 bg-fi-gray/30 border border-white/5 rounded-2xl backdrop-blur-sm hover:border-dynamic-accent-30 transition-all duration-300" data-tilt>
@@ -288,7 +288,7 @@
                             </svg>
                         </div>
                         <h3 class="text-xl font-semibold text-white mb-3">Compliance Guidance</h3>
-                        <p class="text-neutral-400 leading-relaxed">Navigate FedRAMP, FISMA, NIST, and other federal compliance requirements with expert guidance tailored to your solutions.</p>
+                        <p class="text-white leading-relaxed">Navigate FedRAMP, FISMA, NIST, and other federal compliance requirements with expert guidance tailored to your solutions.</p>
                     </div>
 
                     <div class="parallax-card reveal reveal-delay-1 group p-8 bg-fi-gray/30 border border-white/5 rounded-2xl backdrop-blur-sm hover:border-dynamic-accent-30 transition-all duration-300" data-tilt>
@@ -298,7 +298,7 @@
                             </svg>
                         </div>
                         <h3 class="text-xl font-semibold text-white mb-3">AI Readiness Assessment</h3>
-                        <p class="text-neutral-400 leading-relaxed">Evaluate your organization's AI maturity and develop a roadmap for responsible AI adoption aligned with federal guidelines.</p>
+                        <p class="text-white leading-relaxed">Evaluate your organization's AI maturity and develop a roadmap for responsible AI adoption aligned with federal guidelines.</p>
                     </div>
 
                     <div class="parallax-card reveal reveal-delay-2 group p-8 bg-fi-gray/30 border border-white/5 rounded-2xl backdrop-blur-sm hover:border-dynamic-accent-30 transition-all duration-300" data-tilt>
@@ -308,7 +308,7 @@
                             </svg>
                         </div>
                         <h3 class="text-xl font-semibold text-white mb-3">Team Augmentation Strategy</h3>
-                        <p class="text-neutral-400 leading-relaxed">Optimize your technical staffing approach with guidance on skill gaps, hiring strategies, and team structure for federal projects.</p>
+                        <p class="text-white leading-relaxed">Optimize your technical staffing approach with guidance on skill gaps, hiring strategies, and team structure for federal projects.</p>
                     </div>
 
                     <div class="parallax-card reveal reveal-delay-3 group p-8 bg-fi-gray/30 border border-white/5 rounded-2xl backdrop-blur-sm hover:border-dynamic-accent-30 transition-all duration-300" data-tilt>
@@ -318,7 +318,7 @@
                             </svg>
                         </div>
                         <h3 class="text-xl font-semibold text-white mb-3">GovCon Strategy</h3>
-                        <p class="text-neutral-400 leading-relaxed">Strategic guidance on entering and growing in the federal market. From capture to execution, we help you win and deliver.</p>
+                        <p class="text-white leading-relaxed">Strategic guidance on entering and growing in the federal market. From capture to execution, we help you win and deliver.</p>
                     </div>
                 </div>
 
@@ -326,7 +326,7 @@
                 <div class="text-center reveal">
                     <div class="inline-block p-8 bg-fi-gray/30 border border-white/5 rounded-2xl backdrop-blur-sm">
                         <h2 class="text-2xl font-semibold text-white mb-4">Need Expert Guidance?</h2>
-                        <p class="text-neutral-400 mb-6 max-w-lg">Schedule a consultation to discuss how our advisory services can help you navigate technical and strategic challenges.</p>
+                        <p class="text-white mb-6 max-w-lg">Schedule a consultation to discuss how our advisory services can help you navigate technical and strategic challenges.</p>
                         <a href="/contact.html" class="btn-glass group inline-flex items-center space-x-2 text-white font-semibold px-8 py-4 rounded-xl transition-all duration-300">
                             <span>Schedule a Consultation</span>
                             <svg class="w-5 h-5 group-hover:translate-x-1 transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -340,10 +340,10 @@
 
         <footer class="py-8 px-6 md:px-12 lg:px-20 border-t border-white/5">
             <div class="flex flex-col md:flex-row items-center justify-between gap-4">
-                <p class="text-neutral-600 text-sm">&copy; 2026 Federal Innovations. All rights reserved.</p>
-                <div class="flex items-center space-x-1 text-neutral-600 text-sm">
+                <p class="text-white text-sm">&copy; 2026 Federal Innovations. All rights reserved.</p>
+                <div class="flex items-center space-x-1 text-white text-sm">
                     <span>Washington, D.C.</span>
-                    <span class="text-neutral-700">|</span>
+                    <span class="text-white">|</span>
                     <span>Empowering government contractors</span>
                 </div>
             </div>


### PR DESCRIPTION
## Description

This PR improves text contrast and readability across the website by replacing neutral gray text colors (`text-neutral-400`, `text-neutral-300`, `text-neutral-500`) with white (`text-white`) in key areas including dropdown menus, hero sections, stat cards, service descriptions, and body text.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Changes Made

- Changed dropdown menu descriptions from `text-neutral-500` to `text-white` across all service pages
- Updated hero section labels from `text-neutral-400` to `text-white` on Past Performance, Software Engineering, AI Systems, Technical Advisory, Partners, and Contact pages
- Changed hero section body text from `text-neutral-400` to `text-white` and secondary text from `text-neutral-300` to `text-white`
- Updated stat card labels from `text-neutral-400` to `text-white` on Past Performance page
- Changed service card descriptions from `text-neutral-400` to `text-white` across service pages
- Updated partner card descriptions from `text-neutral-400` to `text-white`
- Changed home page status badge and subheading text from `text-neutral-400` to `text-white`
- Updated CSS variable `--color-text-primary` from `#dddddd` to `#ffffff` in example/bg.css

## Testing

- [x] Tested locally in browser
- [x] Verified contrast improvements across multiple pages
- [x] Checked consistency across all service pages and main pages

## Checklist

- [x] My changes follow the project's code style
- [x] I have tested my changes locally
- [x] My changes don't break existing functionality

## Related Issues

Improves accessibility and readability by enhancing text contrast ratios throughout the website.

https://claude.ai/code/session_013K3mTwCqNQAVvN3HHwktoT