### PR TITLE
Fix colors page to sample actual WebGL background colors

### DIFF
--- a/pages/colors.html
+++ b/pages/colors.html
@@ -31,22 +31,6 @@
         color: #ffffff;
         margin-bottom: 4px;
     }
-    .live-swatch {
-        width: 100%;
-        height: 120px;
-        border-radius: 16px;
-        position: relative;
-        overflow: hidden;
-        transition: box-shadow 0.3s ease;
-    }
-    .live-swatch::after {
-        content: '';
-        position: absolute;
-        inset: 0;
-        border-radius: 16px;
-        border: 1px solid rgba(255,255,255,0.1);
-        pointer-events: none;
-    }
     .copied-toast {
         position: fixed;
         bottom: 2rem;
@@ -69,6 +53,20 @@
         transform: translateX(-50%) translateY(0);
         opacity: 1;
     }
+    #colors-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+        gap: 2rem;
+    }
+    .color-card {
+        text-align: center;
+        opacity: 0;
+        transform: translateY(10px);
+        animation: fadeInCard 0.4s ease forwards;
+    }
+    @keyframes fadeInCard {
+        to { opacity: 1; transform: translateY(0); }
+    }
 </style>
 
 <div class="max-w-4xl mx-auto">
@@ -78,64 +76,28 @@
             <svg class="w-5 h-5 text-dynamic-accent" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M7 21a4 4 0 01-4-4V5a2 2 0 012-2h4a2 2 0 012 2v12a4 4 0 01-4 4zm0 0h12a2 2 0 002-2v-4a2 2 0 00-2-2h-2.343M11 7.343l1.657-1.657a2 2 0 012.828 0l2.829 2.829a2 2 0 010 2.828l-8.486 8.485M7 17h.01"/>
             </svg>
-            <span class="text-sm text-white font-medium tracking-wide uppercase">Brand Palette</span>
+            <span class="text-sm text-white font-medium tracking-wide uppercase">Live Background</span>
         </div>
         <h1 class="text-4xl md:text-6xl lg:text-7xl font-bold tracking-tight mb-6 reveal reveal-delay-1">
             <span class="gradient-text">Colors</span>
         </h1>
         <div class="w-24 h-1 glow-line shimmer-line mx-auto mb-8 rounded-full reveal reveal-delay-2"></div>
         <p class="text-lg md:text-xl text-white max-w-3xl mx-auto leading-relaxed reveal reveal-delay-2">
-            The primary colors cycling through the background right now.
+            The dominant colors in the background right now, sampled live from the particle canvas.
         </p>
     </div>
 
-    <!-- Live Current Color -->
+    <!-- Live Sampled Colors -->
     <div class="mb-16 reveal reveal-delay-1">
         <div class="p-8 bg-fi-gray/30 border border-white/5 rounded-2xl backdrop-blur-sm">
-            <h2 class="text-xl font-semibold text-white mb-2">Current Color</h2>
-            <p class="text-sm text-neutral-400 mb-6">Interpolated live from the palette below</p>
-            <div id="live-color-swatch" class="live-swatch mb-4"></div>
-            <div class="flex items-center justify-between">
-                <span id="live-hex" class="color-label cursor-pointer hover:text-white transition-colors" title="Click to copy"></span>
-                <span id="live-rgb" class="color-label"></span>
+            <div class="flex items-center justify-between mb-8">
+                <div>
+                    <h2 class="text-xl font-semibold text-white mb-1">Primary Colors</h2>
+                    <p class="text-sm text-neutral-400">Sampled from the WebGL background &mdash; updates every second</p>
+                </div>
+                <div id="sampling-indicator" class="w-2.5 h-2.5 rounded-full bg-green-500 animate-pulse" title="Sampling active"></div>
             </div>
-        </div>
-    </div>
-
-    <!-- Palette Colors -->
-    <div class="mb-16 reveal reveal-delay-2">
-        <div class="p-8 bg-fi-gray/30 border border-white/5 rounded-2xl backdrop-blur-sm">
-            <h2 class="text-xl font-semibold text-white mb-2">Palette</h2>
-            <p class="text-sm text-neutral-400 mb-8">The background continuously cycles through these colors</p>
-            <div class="grid grid-cols-1 sm:grid-cols-3 gap-8" id="palette-grid">
-                <!-- Purple -->
-                <div class="text-center">
-                    <div class="color-swatch" style="background: #8b5cf6; box-shadow: 0 8px 32px rgba(139,92,246,0.3);" data-hex="#8b5cf6" title="Click to copy"></div>
-                    <div class="mt-4">
-                        <div class="color-name">Purple</div>
-                        <div class="color-label cursor-pointer hover:text-white transition-colors" data-hex="#8b5cf6" title="Click to copy">#8b5cf6</div>
-                        <div class="color-label">rgb(139, 92, 246)</div>
-                    </div>
-                </div>
-                <!-- Blue -->
-                <div class="text-center">
-                    <div class="color-swatch" style="background: #3b82f6; box-shadow: 0 8px 32px rgba(59,130,246,0.3);" data-hex="#3b82f6" title="Click to copy"></div>
-                    <div class="mt-4">
-                        <div class="color-name">Blue</div>
-                        <div class="color-label cursor-pointer hover:text-white transition-colors" data-hex="#3b82f6" title="Click to copy">#3b82f6</div>
-                        <div class="color-label">rgb(59, 130, 246)</div>
-                    </div>
-                </div>
-                <!-- Amber -->
-                <div class="text-center">
-                    <div class="color-swatch" style="background: #f59e0b; box-shadow: 0 8px 32px rgba(245,158,11,0.3);" data-hex="#f59e0b" title="Click to copy"></div>
-                    <div class="mt-4">
-                        <div class="color-name">Amber</div>
-                        <div class="color-label cursor-pointer hover:text-white transition-colors" data-hex="#f59e0b" title="Click to copy">#f59e0b</div>
-                        <div class="color-label">rgb(245, 158, 11)</div>
-                    </div>
-                </div>
-            </div>
+            <div id="colors-grid"></div>
         </div>
     </div>
 </div>
@@ -147,39 +109,13 @@
 (function() {
     'use strict';
 
-    var liveSwatch = document.getElementById('live-color-swatch');
-    var liveHex = document.getElementById('live-hex');
-    var liveRgb = document.getElementById('live-rgb');
+    var grid = document.getElementById('colors-grid');
     var toast = document.getElementById('copied-toast');
     var toastTimer;
 
     function toHex(r, g, b) {
         return '#' + ((1 << 24) + (r << 16) + (g << 8) + b).toString(16).slice(1);
     }
-
-    function updateLiveColor() {
-        var style = getComputedStyle(document.documentElement);
-        var r = parseInt(style.getPropertyValue('--dynamic-r')) || 0;
-        var g = parseInt(style.getPropertyValue('--dynamic-g')) || 0;
-        var b = parseInt(style.getPropertyValue('--dynamic-b')) || 0;
-        var hex = toHex(r, g, b);
-
-        if (liveSwatch) {
-            liveSwatch.style.background = hex;
-            liveSwatch.style.boxShadow = '0 8px 32px rgba(' + r + ',' + g + ',' + b + ',0.35)';
-        }
-        if (liveHex) {
-            liveHex.textContent = hex;
-            liveHex.setAttribute('data-hex', hex);
-        }
-        if (liveRgb) {
-            liveRgb.textContent = 'rgb(' + r + ', ' + g + ', ' + b + ')';
-        }
-
-        requestAnimationFrame(updateLiveColor);
-    }
-
-    requestAnimationFrame(updateLiveColor);
 
     function showToast(text) {
         toast.textContent = text;
@@ -198,12 +134,161 @@
         }
     }
 
-    // Click-to-copy on swatches and hex labels
-    document.querySelectorAll('.color-swatch[data-hex], .color-label[data-hex], #live-hex').forEach(function(el) {
-        el.addEventListener('click', function() {
-            var hex = el.getAttribute('data-hex');
-            if (hex) copyHex(hex);
+    // Convert RGB to HSL
+    function rgbToHsl(r, g, b) {
+        r /= 255; g /= 255; b /= 255;
+        var max = Math.max(r, g, b), min = Math.min(r, g, b);
+        var h, s, l = (max + min) / 2;
+        if (max === min) {
+            h = s = 0;
+        } else {
+            var d = max - min;
+            s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
+            if (max === r) h = ((g - b) / d + (g < b ? 6 : 0)) / 6;
+            else if (max === g) h = ((b - r) / d + 2) / 6;
+            else h = ((r - g) / d + 4) / 6;
+        }
+        return { h: h * 360, s: s, l: l };
+    }
+
+    // Color distance in HSL space (weighted)
+    function colorDist(a, b) {
+        var dh = Math.min(Math.abs(a.h - b.h), 360 - Math.abs(a.h - b.h)) / 180;
+        var ds = Math.abs(a.s - b.s);
+        var dl = Math.abs(a.l - b.l);
+        return dh * 2 + ds + dl;
+    }
+
+    // Name a color from its hue/saturation/lightness
+    function nameColor(hsl) {
+        if (hsl.s < 0.1) return hsl.l < 0.2 ? 'Black' : hsl.l < 0.8 ? 'Gray' : 'White';
+        var h = hsl.h;
+        if (h < 15) return 'Red';
+        if (h < 40) return 'Orange';
+        if (h < 65) return 'Yellow';
+        if (h < 160) return 'Green';
+        if (h < 190) return 'Cyan';
+        if (h < 260) return 'Blue';
+        if (h < 290) return 'Purple';
+        if (h < 340) return 'Pink';
+        return 'Red';
+    }
+
+    // Sample dominant colors from the canvas
+    function sampleCanvas() {
+        var canvas = document.getElementById('canvas');
+        if (!canvas) return [];
+
+        var gl = canvas.getContext('webgl') || canvas.getContext('webgl2');
+        if (!gl) return [];
+
+        var w = canvas.width;
+        var h = canvas.height;
+
+        // Sample a grid of points across the canvas
+        var step = Math.max(4, Math.floor(Math.min(w, h) / 80));
+        var pixels = new Uint8Array(4);
+        var buckets = [];
+
+        for (var y = 0; y < h; y += step) {
+            for (var x = 0; x < w; x += step) {
+                gl.readPixels(x, y, 1, 1, gl.RGBA, gl.UNSIGNED_BYTE, pixels);
+                var r = pixels[0], g = pixels[1], b = pixels[2];
+
+                // Skip near-black pixels (the background)
+                if (r + g + b < 30) continue;
+
+                var hsl = rgbToHsl(r, g, b);
+                // Skip very dark or desaturated pixels
+                if (hsl.l < 0.04 || hsl.s < 0.08) continue;
+
+                // Try to merge into existing bucket
+                var merged = false;
+                for (var i = 0; i < buckets.length; i++) {
+                    if (colorDist(hsl, buckets[i].hsl) < 0.35) {
+                        buckets[i].count++;
+                        // Running average
+                        var c = buckets[i].count;
+                        buckets[i].r = Math.round(buckets[i].r + (r - buckets[i].r) / c);
+                        buckets[i].g = Math.round(buckets[i].g + (g - buckets[i].g) / c);
+                        buckets[i].b = Math.round(buckets[i].b + (b - buckets[i].b) / c);
+                        buckets[i].hsl = rgbToHsl(buckets[i].r, buckets[i].g, buckets[i].b);
+                        merged = true;
+                        break;
+                    }
+                }
+                if (!merged) {
+                    buckets.push({ r: r, g: g, b: b, hsl: hsl, count: 1 });
+                }
+            }
+        }
+
+        // Sort by count (most common first) and take top 5
+        buckets.sort(function(a, b) { return b.count - a.count; });
+        return buckets.slice(0, 5);
+    }
+
+    function renderColors(colors) {
+        if (!grid) return;
+        grid.innerHTML = '';
+
+        if (colors.length === 0) {
+            grid.innerHTML = '<p class="text-neutral-500 text-sm col-span-full text-center py-8">Waiting for background to render&hellip;</p>';
+            return;
+        }
+
+        colors.forEach(function(c, i) {
+            var hex = toHex(c.r, c.g, c.b);
+            var name = nameColor(c.hsl);
+
+            var card = document.createElement('div');
+            card.className = 'color-card';
+            card.style.animationDelay = (i * 0.08) + 's';
+
+            var swatch = document.createElement('div');
+            swatch.className = 'color-swatch';
+            swatch.style.background = hex;
+            swatch.style.boxShadow = '0 8px 32px rgba(' + c.r + ',' + c.g + ',' + c.b + ',0.35)';
+            swatch.title = 'Click to copy ' + hex;
+            swatch.addEventListener('click', function() { copyHex(hex); });
+
+            var info = document.createElement('div');
+            info.className = 'mt-4';
+
+            var nameEl = document.createElement('div');
+            nameEl.className = 'color-name';
+            nameEl.textContent = name;
+
+            var hexEl = document.createElement('div');
+            hexEl.className = 'color-label cursor-pointer hover:text-white transition-colors';
+            hexEl.textContent = hex;
+            hexEl.title = 'Click to copy';
+            hexEl.addEventListener('click', function() { copyHex(hex); });
+
+            var rgbEl = document.createElement('div');
+            rgbEl.className = 'color-label';
+            rgbEl.textContent = 'rgb(' + c.r + ', ' + c.g + ', ' + c.b + ')';
+
+            info.appendChild(nameEl);
+            info.appendChild(hexEl);
+            info.appendChild(rgbEl);
+            card.appendChild(swatch);
+            card.appendChild(info);
+            grid.appendChild(card);
         });
-    });
+    }
+
+    function update() {
+        var colors = sampleCanvas();
+        if (colors.length > 0) {
+            renderColors(colors);
+        }
+    }
+
+    // Initial sample after a short delay (let WebGL render)
+    setTimeout(update, 500);
+
+    // Re-sample every second
+    setInterval(update, 1000);
 })();
 </script>


### PR DESCRIPTION
Instead of showing hardcoded accent palette colors, the page now reads pixels directly from the WebGL particle canvas every second, clusters them by hue, and displays the 3-5 dominant colors currently visible in the background with live hex/rgb values and click-to-copy.

https://claude.ai/code/session_01UTi12tq7nCLm9ZVmiVrjS9

## Description

Brief description of the changes in this PR.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Changes Made

- Change 1
- Change 2

## Testing

Describe how you tested your changes:

- [ ] Tested locally in browser
- [ ] Tested on mobile viewport
- [ ] Tested in multiple browsers (list which ones)

## Checklist

- [ ] My changes follow the project's code style
- [ ] I have tested my changes locally
- [ ] I have updated documentation if needed
- [ ] My changes don't break existing functionality

## Screenshots (if applicable)

Add screenshots showing the changes.

## Related Issues

Closes #(issue number)
