### PR TITLE
Fix Federal Innovations header spacing across pages

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -181,7 +181,7 @@
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 10V3L4 14h7v7l9-11h-7z"/>
                         </svg>
                     </div>
-                    <span class="text-xl font-semibold text-white tracking-tight">Federal<span class="text-dynamic-accent">Innovations</span></span>
+                    <span class="text-xl font-semibold text-white tracking-tight">Federal <span class="text-dynamic-accent">Innovations</span></span>
                 </a>
                 <div class="desktop-nav hidden md:flex items-center space-x-8">
                     <a href="/" class="nav-link font-medium">Home</a>

--- a/index.html
+++ b/index.html
@@ -548,7 +548,7 @@
                         </svg>
                     </div>
                     <span class="text-2xl font-display font-semibold text-white tracking-tight">
-                        Federal<span class="text-dynamic-accent">Innovations</span>
+                        Federal <span class="text-dynamic-accent">Innovations</span>
                     </span>
                 </a>
 

--- a/partners.html
+++ b/partners.html
@@ -164,7 +164,7 @@
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 10V3L4 14h7v7l9-11h-7z"/>
                         </svg>
                     </div>
-                    <span class="text-xl font-semibold text-white tracking-tight">Federal<span class="text-dynamic-accent">Innovations</span></span>
+                    <span class="text-xl font-semibold text-white tracking-tight">Federal <span class="text-dynamic-accent">Innovations</span></span>
                 </a>
                 <div class="desktop-nav hidden md:flex items-center space-x-8">
                     <a href="/" class="nav-link font-medium">Home</a>

--- a/past-performance.html
+++ b/past-performance.html
@@ -164,7 +164,7 @@
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 10V3L4 14h7v7l9-11h-7z"/>
                         </svg>
                     </div>
-                    <span class="text-xl font-semibold text-white tracking-tight">Federal<span class="text-dynamic-accent">Innovations</span></span>
+                    <span class="text-xl font-semibold text-white tracking-tight">Federal <span class="text-dynamic-accent">Innovations</span></span>
                 </a>
                 <div class="desktop-nav hidden md:flex items-center space-x-8">
                     <a href="/" class="nav-link font-medium">Home</a>

--- a/services/ai-systems.html
+++ b/services/ai-systems.html
@@ -168,7 +168,7 @@
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 10V3L4 14h7v7l9-11h-7z"/>
                         </svg>
                     </div>
-                    <span class="text-xl font-semibold text-white tracking-tight">Federal<span class="text-dynamic-accent">Innovations</span></span>
+                    <span class="text-xl font-semibold text-white tracking-tight">Federal <span class="text-dynamic-accent">Innovations</span></span>
                 </a>
                 <div class="desktop-nav hidden md:flex items-center space-x-8">
                     <a href="/" class="nav-link font-medium">Home</a>

--- a/services/software-engineering.html
+++ b/services/software-engineering.html
@@ -220,7 +220,7 @@
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 10V3L4 14h7v7l9-11h-7z"/>
                         </svg>
                     </div>
-                    <span class="text-xl font-semibold text-white tracking-tight">Federal<span class="text-dynamic-accent">Innovations</span></span>
+                    <span class="text-xl font-semibold text-white tracking-tight">Federal <span class="text-dynamic-accent">Innovations</span></span>
                 </a>
                 <div class="desktop-nav hidden md:flex items-center space-x-8">
                     <a href="/" class="nav-link font-medium">Home</a>

--- a/services/technical-advisory.html
+++ b/services/technical-advisory.html
@@ -168,7 +168,7 @@
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 10V3L4 14h7v7l9-11h-7z"/>
                         </svg>
                     </div>
-                    <span class="text-xl font-semibold text-white tracking-tight">Federal<span class="text-dynamic-accent">Innovations</span></span>
+                    <span class="text-xl font-semibold text-white tracking-tight">Federal <span class="text-dynamic-accent">Innovations</span></span>
                 </a>
                 <div class="desktop-nav hidden md:flex items-center space-x-8">
                     <a href="/" class="nav-link font-medium">Home</a>


### PR DESCRIPTION
### Motivation
- The site brand wordmark should render as two words, "Federal Innovations", with the accent styling applied only to the second word and a visible space between them for consistent branding across the site.

### Description
- Inserted a space before the styled `<span class="text-dynamic-accent">Innovations</span>` in the header wordmark across top-level pages to change `Federal<span ...>Innovations</span>` → `Federal <span ...>Innovations</span>`.
- Applied the change consistently to `index.html`, `contact.html`, `partners.html`, `past-performance.html`, `services/software-engineering.html`, `services/technical-advisory.html`, and `services/ai-systems.html`.
- This is a minimal content-only change (whitespace/markup) with no CSS or JS modifications.

### Testing
- Ran `rg -n "Federal<span|Federal <span" index.html partners.html contact.html past-performance.html services/*.html` and confirmed the files now contain only the spaced variant, so the replacement succeeded.
- Inspected the updated header lines with `nl` to verify the exact markup change was applied, which passed.
- No automated unit tests exist for the static HTML; the change was committed successfully after verification.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7e6f631b0832db0fa75e2fb886141)